### PR TITLE
Fix inconsistent hostname handling

### DIFF
--- a/bin/mkrc
+++ b/bin/mkrc
@@ -12,7 +12,7 @@ destination() {
   if [ "x$tag" != "x" ]; then
     echo $dotfiles_dir/tag-$tag
   elif [ $in_host = 1 ]; then
-    echo $dotfiles_dir/host-`hostname`
+    echo $dotfiles_dir/host-$HOSTNAME
   else
     echo $dotfiles_dir
   fi


### PR DESCRIPTION
`lsrc` was stripping hostname domain suffixes, but `mkrc` was not meaning
that `mkrc -o` didn't work correctly with a suffix. This was particularly
noticeable on OS X where the hostname has a `.local` suffix by default.
