### PR TITLE
Add better feedback to the user when adding new files

### DIFF
--- a/bin/mkrc
+++ b/bin/mkrc
@@ -75,6 +75,6 @@ for file in $files; do
   dotless=`echo $file | sed -e "s|$DEST_DIR/||" | sed -e 's/^\.//'`
   dest=`destination $DOTFILES_DIR $dotless $in_host $tag`
   mkdir -p $dest/`dirname $dotless`
-  $MV $file $dest/$dotless
-  $INSTALL -d $DOTFILES_DIR -t ${tag:--} $dotless
+  echo -n "Moving... "; $MV $file $dest/$dotless
+  echo -n "Linking... "; $INSTALL -d $DOTFILES_DIR -t ${tag:--} $dotless
 done


### PR DESCRIPTION
I found that after you add a file with `mkrc` command from any dir, the output
looks like:

```
$ mkrc ~/.my-awesome-dot-file
‘$HOME/.my-awesome-dot-file -> ‘$HOME/.dotfiles/my-awesome-dot-file'
‘$HOME/.my-awesome-dot-file -> ‘$HOME/.dotfiles/my-awesome-dot-file'
$
```

It looks like the output it's appearing twice, which could led you believe
something went wrong or the output is a bit buggy. Obivously, it's not, and
the command ran without problems. This little patch improves the feedback to
the user making clear that those are two different process rather than one
that's being repeated.
