### PR TITLE
Improve ~/.rcrc handling

### DIFF
--- a/bin/lsrc
+++ b/bin/lsrc
@@ -242,10 +242,6 @@ handle_command_line() {
 
 DEST_STACK=
 
-if [ -e $HOME/.rcrc ]; then
-  . $HOME/.rcrc
-fi
-
 handle_command_line $*
 
 : ${DOTFILES_DIRS:=$DOTFILES_DIRS $DEFAULT_DOTFILES_DIR}

--- a/bin/mkrc
+++ b/bin/mkrc
@@ -18,10 +18,6 @@ destination() {
   fi
 }
 
-if [ -e $HOME/.rcrc ]; then
-  . $HOME/.rcrc
-fi
-
 show_help() {
   local exit_code=${1:-0}
 

--- a/bin/rcdn
+++ b/bin/rcdn
@@ -79,10 +79,6 @@ handle_command_line() {
 
 LS_ARGS=-F
 
-if [ -e $HOME/.rcrc ]; then
-  . $HOME/.rcrc
-fi
-
 handle_command_line $*
 : ${DOTFILES_DIRS:=$DOTFILES_DIRS $DEFAULT_DOTFILES_DIR}
 

--- a/bin/rcup
+++ b/bin/rcup
@@ -155,10 +155,6 @@ handle_command_line() {
 
 LS_ARGS=-F
 
-if [ -e $HOME/.rcrc ]; then
-  . $HOME/.rcrc
-fi
-
 handle_command_line $*
 : ${DOTFILES_DIRS:=$DOTFILES_DIRS $DEFAULT_DOTFILES_DIR}
 

--- a/man/lsrc.1
+++ b/man/lsrc.1
@@ -93,6 +93,12 @@ Or more simply:
 .Pp
 .Dl bash_profile
 .Pp
+.Sh ENVIRONMENT
+.Bl -tag -width ".Ev RCRC"
+.It Ev RCRC
+User configuration file. Defaults to
+.Pa ~/.rcrc .
+.El
 .Sh FILES
 .Pa ~/.dotfiles
 .Pa ~/.rcrc

--- a/man/mkrc.1
+++ b/man/mkrc.1
@@ -33,6 +33,12 @@ install dotfiles according to tag
 .It Fl v
 increase verbosity. This can be repeated for extra verbosity.
 .El
+.Sh ENVIRONMENT
+.Bl -tag -width ".Ev RCRC"
+.It Ev RCRC
+User configuration file. Defaults to
+.Pa ~/.rcrc .
+.El
 .Sh FILES
 .Pa ~/.dotfiles
 .Pa ~/.rcrc

--- a/man/rcdn.1
+++ b/man/rcdn.1
@@ -86,6 +86,12 @@ only remove the specified file(s)
 .Dl rcdn -t python
 .Dl rcdn -d ~/corporate-dotfiles
 .Dl rcdn -e '*:.zshrc'
+.Sh ENVIRONMENT
+.Bl -tag -width ".Ev RCRC"
+.It Ev RCRC
+User configuration file. Defaults to
+.Pa ~/.rcrc .
+.El
 .Sh FILES
 .Pa ~/.rcrc
 .Sh SEE ALSO

--- a/man/rcrc.5
+++ b/man/rcrc.5
@@ -17,8 +17,9 @@
 .Sh DESCRIPTION
 The rcm dotfile manager can be configured using a
 .Pa .rcrc
-file in your home directory. The format is POSIX shell. It is
-sourced in by the
+file in your home directory. This location can be changed by setting the
+.Pa RCRC
+environment variable. The format is POSIX shell. It is sourced in by the
 .Xr lsrc 1 ,
 .Xr mkrc 1 ,
 .Xr rcdn 1 ,

--- a/man/rcup.1
+++ b/man/rcup.1
@@ -170,6 +170,12 @@ or from
 The post-up hook is run.
 .El
 .
+.Sh ENVIRONMENT
+.Bl -tag -width ".Ev RCRC"
+.It Ev RCRC
+User configuration file. Defaults to
+.Pa ~/.rcrc .
+.El
 .Sh FILES
 .Pa ~/.dotfiles
 .Pa ~/.rcrc

--- a/share/rcm.sh.in
+++ b/share/rcm.sh.in
@@ -116,3 +116,9 @@ run_hooks() {
     done
   fi
 }
+
+: ${RCRC:=$HOME/.rcrc}
+
+if [ -r "$RCRC" ]; then
+  . "$RCRC"
+fi


### PR DESCRIPTION
- Centralize in rcm.sh(.in)
- Check readability, not just existence
- Allow location override via RCRC environment variable

This may or may not close #16 where we're currently discussing other
names or directory layouts for configuration. For that reason, this PR
could be considered a backwards-compatible improvement for the time
being.
