### PR TITLE
Files created in wrong locations if CDPATH environment variable is set with any values

### DIFF
--- a/share/rcm.sh.in
+++ b/share/rcm.sh.in
@@ -18,6 +18,8 @@ INSTALL=rcup
 ROOT_DIR=$HOME
 HOSTNAME=`hostname -s`
 
+unset CDPATH
+
 echo_n() {
   printf "%s " "$*"
 }


### PR DESCRIPTION
`rcup` creates symlinks to folders in the current folder for subfolders of folders in the dotfiles directory if the `CDPATH` environment variable is set. 

Originally I thought the problem was that my dotfiles folder was in the CDPATH, but I tested with CDPATH only set to equal `.` and experienced the same problem.

I think the solution might be to copy `CDPATH` environment variable's contents to a temporary variable, `unset CDPATH`, execute the tasks, then copy the value back at the conclusion of the script. However, I'm not a shell script expert, so there might be a much better option I'm missing.
