### PR TITLE
Fixed typo in rcm manpage

### DIFF
--- a/man/rcm.7
+++ b/man/rcm.7
@@ -142,7 +142,7 @@ will be a symlink to
 .Sh TAGGED DOTFILES
 This suite becomes more powerful if you share your dotfiles directory
 between computers, either because multiple people share the same
-directory or because you have mutliple computers.
+directory or because you have multiple computers.
 .Pp
 If you share the dotfiles directory between people, you may end up with
 some irrelevant or even incorrect rc files. For example, you may have a


### PR DESCRIPTION
Sorry to submit a pull request over something so trivial but I bumped into the typo while reading through the rcm manpage.
