### PR TITLE
Use the new central thoughtbot homebrew repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Debian-based (including Ubuntu):
 
 OS X:
 
-    brew tap thoughtbot/rcm
+    brew tap thoughtbot/formulae
     brew install rcm
 
 Elsewhere:


### PR DESCRIPTION
Updates the install instructions to use the new central thoughtbot homebrew repo.

See also:
- https://github.com/thoughtbot/homebrew-formulae/pull/1
- https://github.com/thoughtbot/gitsh/pull/59
- https://github.com/thoughtbot/homebrew-rcm/pull/3
