### PR TITLE
Use sed to split out the short hostname

### DIFF
--- a/share/rcm.sh.in
+++ b/share/rcm.sh.in
@@ -16,7 +16,7 @@ DEFAULT_DOTFILES_DIR=$HOME/.dotfiles
 MV=mv
 INSTALL=rcup
 ROOT_DIR=$HOME
-HOSTNAME=`hostname -s`
+HOSTNAME=`hostname | sed -e 's/\..*//'`
 
 unset CDPATH
 


### PR DESCRIPTION
Instead of using the non-standard `-s` argument to `hostname`, use `sed`
to split out everything after the first period. This fixes lsrc(1) on
Cygwin, among others.

Fixes #28.
