### PR TITLE
Add quoting, remove backticks, use $PWD

### DIFF
--- a/bin/lsrc
+++ b/bin/lsrc
@@ -1,20 +1,20 @@
 #!/bin/sh
 
-: ${RCM_LIB:=`dirname $0`/../share/rcm}
-. $RCM_LIB/rcm.sh
+: ${RCM_LIB:=$(dirname "$0")/../share/rcm}
+. "$RCM_LIB/rcm.sh"
 
 pushdir() {
   DIR_STACK="$DIR_STACK:$PWD/$1"
-  $DEBUG "cd'ing to $1 from `pwd` with stack $DIR_STACK"
-  cd $1
+  $DEBUG "cd'ing to $1 from $PWD with stack $DIR_STACK"
+  cd "$1"
 }
 
 popdir() {
-  current=`echo $DIR_STACK | sed -e 's/.*://g'`
-  prior=`echo $DIR_STACK | sed -e "s|:$current$||" | sed -e 's/.*://g'`
-  DIR_STACK=`echo $DIR_STACK | sed -e 's/:[^:]*$//'`
-  $DEBUG "cd'ing to $prior from `pwd` with stack $DIR_STACK"
-  cd $prior
+  current="$(echo "$DIR_STACK" | sed -e 's/.*://g')"
+  prior="$(echo "$DIR_STACK" | sed -e "s|:$current$||" | sed -e 's/.*://g')"
+  DIR_STACK="$(echo "$DIR_STACK" | sed -e 's/:[^:]*$//')"
+  $DEBUG "cd'ing to $prior from $PWD with stack $DIR_STACK"
+  cd "$prior"
 }
 
 build_path() {
@@ -46,15 +46,15 @@ file_join() {
 }
 
 show_dir() {
-  local dir=$1
-  local dest_dir=$2
-  local dotfiles_dir=$3
-  local dotfiles_subdir=$4
+  local dir="$1"
+  local dest_dir="$2"
+  local dotfiles_dir="$3"
+  local dotfiles_subdir="$4"
   local dotted=$5
   local exclude_file_globs="$6"
   local include_file_globs="$7"
   local symlink_dirs_file_globs="$8"
-  local dest_path=`build_path "$dest_dir" "$dir" $dotted`
+  local dest_path="$(build_path "$dest_dir" "$dir" $dotted)"
 
   $DEBUG "show_dir $1 $2 $3 $4 $5 $6 $7 $8"
 
@@ -63,15 +63,15 @@ show_dir() {
   pushdir "$dir"
   for f in *; do
     $DEBUG "handling the file $f"
-    next_dir=`file_join "$dotfiles_subdir" "$dir"`
+    next_dir="$(file_join "$dotfiles_subdir" "$dir")"
     handle_file "$f" "$dest_path" "$dotfiles_dir" "$next_dir" 1 "$exclude_file_globs" "$include_file_globs" "$symlink_dirs_file_globs"
   done
   popdir
 }
 
 sigil_for() {
-  local file=$1
-  local symlink_dirs_file_globs=$2
+  local file="$1"
+  local symlink_dirs_file_globs="$2"
   local copy_always=0
   local symlink_dirs=0
 
@@ -79,7 +79,7 @@ sigil_for() {
     $DEBUG "copy_file: $copy_file"
     $DEBUG "file: $file"
 
-    case $file in
+    case "$file" in
       $copy_file)
         copy_always=1
         break
@@ -107,17 +107,17 @@ show_file() {
   local dotfiles_subdir="$4"
   local dotted=$5
   local symlink_dirs_file_globs="$6"
-  local dest_file=`build_path "$dest_dir" "$file" $dotted`
+  local dest_file="$(build_path "$dest_dir" "$file" $dotted)"
 
-  if echo $DEST_STACK | grep -vq ":$dest_file"; then
+  if echo "$DEST_STACK" | grep -vq ":$dest_file"; then
     DEST_STACK="$DEST_STACK:$dest_file"
 
-    src_file=`file_join "$dotfiles_subdir" "$file"`
-    abs_src_file=`file_join "$dotfiles_dir" "$src_file"`
+    src_file="$(file_join "$dotfiles_subdir" "$file")"
+    abs_src_file="$(file_join "$dotfiles_dir" "$src_file")"
     output="$dest_file:$abs_src_file"
 
     if [ $SHOW_SIGILS -eq 1 ]; then
-      sigil=`sigil_for "$src_file" "$symlink_dirs_file_globs"`
+      sigil="$(sigil_for "$src_file" "$symlink_dirs_file_globs")"
       output="$output:$sigil"
     fi
 
@@ -151,10 +151,10 @@ handle_file() {
 }
 
 is_metafile() {
-  host_portion=`echo $1 | sed -e 's/host-.*/host-/'`
-  tag_portion=`echo $1 | sed -e 's/tag-.*/tag-/'`
+  host_portion="$(echo "$1" | sed -e 's/host-.*/host-/')"
+  tag_portion="$(echo "$1" | sed -e 's/tag-.*/tag-/')"
 
-  [ x$host_portion = 'xhost-' -o x$tag_portion = 'xtag-' -o "x$1" = "xhooks" ]
+  [ "x$host_portion" = 'xhost-' -o "x$tag_portion" = 'xtag-' -o "x$1" = "xhooks" ]
 }
 
 dotfiles_dir_excludes() {
@@ -165,19 +165,19 @@ dotfiles_dir_excludes() {
   $DEBUG "  with excludes: $excludes"
 
   for exclude in $excludes; do
-    if echo $exclude | grep -q :; then
-      dotfiles_dir_pat=`echo $exclude | sed 's/:.*//'`
-      file_glob=`echo $exclude | sed 's/.*://'`
+    if echo "$exclude" | grep -q ':'; then
+      dotfiles_dir_pat="$(echo "$exclude" | sed 's/:.*//')"
+      file_glob="$(echo "$exclude" | sed 's/.*://')"
 
-      if [ "x$dotfiles_dir_pat" != "x*" ] && is_relative $dotfiles_dir_pat; then
-        dotfiles_dir_pat=$PWD/$dotfiles_dir_pat
+      if [ "x$dotfiles_dir_pat" != "x*" ] && is_relative "$dotfiles_dir_pat"; then
+        dotfiles_dir_pat="$PWD/$dotfiles_dir_pat"
       fi
 
       if [ "x$dotfiles_dir_pat" = "x*" -o "x$dotfiles_dir_pat" = "x$dotfiles_dir" ]; then
-        echo $file_glob
+        echo "$file_glob"
       fi
     else
-      echo $exclude
+      echo "$exclude"
     fi
   done
 }
@@ -246,12 +246,12 @@ handle_command_line() {
 
   handle_common_flags lsrc $version $verbosity
   SHOW_SIGILS=$show_sigils
-  TAGS=${arg_tags:-$TAGS}
-  DOTFILES_DIRS=${dotfiles_dirs:-$DOTFILES_DIRS}
-  EXCLUDES=${excludes:-$EXCLUDES}
-  INCLUDES=${includes:-$INCLUDES}
-  SYMLINK_DIRS=${symlink_dirs:-$SYMLINK_DIRS}
-  FILES=$@
+  TAGS="${arg_tags:-$TAGS}"
+  DOTFILES_DIRS="${dotfiles_dirs:-$DOTFILES_DIRS}"
+  EXCLUDES="${excludes:-$EXCLUDES}"
+  INCLUDES="${includes:-$INCLUDES}"
+  SYMLINK_DIRS="${symlink_dirs:-$SYMLINK_DIRS}"
+  FILES="$@"
 
   $DEBUG "TAGS: $TAGS"
   $DEBUG "DOTFILES_DIRS: $DOTFILES_DIRS"
@@ -259,7 +259,7 @@ handle_command_line() {
 
 DEST_STACK=
 
-handle_command_line $*
+handle_command_line $@
 
 : ${DOTFILES_DIRS:=$DOTFILES_DIRS $DEFAULT_DOTFILES_DIR}
 $DEBUG "DOTFILES_DIRS: $DOTFILES_DIRS"
@@ -276,7 +276,7 @@ for DOTFILES_DIR in $DOTFILES_DIRS; do
   cd "$relative_root_dir"
 
   if is_relative $DOTFILES_DIR; then
-    DOTFILES_DIR=$PWD/$DOTFILES_DIR
+    DOTFILES_DIR="$PWD/$DOTFILES_DIR"
   fi
 
   if [ ! -d "$DOTFILES_DIR" ]; then
@@ -284,30 +284,30 @@ for DOTFILES_DIR in $DOTFILES_DIRS; do
     continue
   fi
 
-  exclude_file_globs=`dotfiles_dir_excludes $DOTFILES_DIR "$EXCLUDES"`
+  exclude_file_globs="$(dotfiles_dir_excludes "$DOTFILES_DIR" "$EXCLUDES")"
   $DEBUG "exclude_file_globs: $exclude_file_globs"
-  include_file_globs=`dotfiles_dir_excludes $DOTFILES_DIR "$INCLUDES"`
-  symlink_dirs_file_globs=`dotfiles_dir_excludes $DOTFILES_DIR "$SYMLINK_DIRS"`
+  include_file_globs="$(dotfiles_dir_excludes "$DOTFILES_DIR" "$INCLUDES")"
+  symlink_dirs_file_globs="$(dotfiles_dir_excludes "$DOTFILES_DIR" "$SYMLINK_DIRS")"
   $DEBUG "symlink_dirs_file_globs: $symlink_dirs_file_globs"
 
   cd "$DOTFILES_DIR"
   DIR_STACK=":$DOTFILES_DIR"
 
   for file in ${FILES:-*}; do
-    if is_metafile $file; then
+    if is_metafile "$file"; then
       continue
     fi
 
-    handle_file $file $DEST_DIR $DOTFILES_DIR . 0 "$exclude_file_globs" "$include_file_globs" "$symlink_dirs_file_globs"
+    handle_file "$file" "$DEST_DIR" "$DOTFILES_DIR" . 0 "$exclude_file_globs" "$include_file_globs" "$symlink_dirs_file_globs"
   done
 
   cd "$DOTFILES_DIR"
 
-  host_files=$DOTFILES_DIR/host-$HOSTNAME
-  if [ -d $host_files ]; then
-    pushdir `basename $host_files`
+  host_files="$DOTFILES_DIR/host-$HOSTNAME"
+  if [ -d "$host_files" ]; then
+    pushdir "$(basename "$host_files")"
     for file in ${FILES:-*}; do
-      handle_file $file $DEST_DIR $host_files . 0 "$exclude_file_globs" "$include_file_globs"
+      handle_file "$file" "$DEST_DIR" "$host_files" . 0 "$exclude_file_globs" "$include_file_globs"
     done
     popdir
   fi
@@ -315,11 +315,11 @@ for DOTFILES_DIR in $DOTFILES_DIRS; do
   cd "$DOTFILES_DIR"
 
   for tag in $TAGS; do
-    if [ -d tag-$tag ]; then
-      pushdir `basename tag-$tag`
+    if [ -d "tag-$tag" ]; then
+      pushdir "$(basename "tag-$tag")"
       for file in ${FILES:-*}; do
         $DEBUG "TAG: $tag, exclude_file_globs: $exclude_file_globs"
-        handle_file $file $DEST_DIR $DOTFILES_DIR/tag-$tag . 0 "$exclude_file_globs" "$include_file_globs"
+        handle_file "$file" "$DEST_DIR" "$DOTFILES_DIR/tag-$tag" . 0 "$exclude_file_globs" "$include_file_globs"
       done
       popdir
     fi

--- a/bin/mkrc
+++ b/bin/mkrc
@@ -1,20 +1,20 @@
 #!/bin/sh
 
-: ${RCM_LIB:=`dirname $0`/../share/rcm}
-. $RCM_LIB/rcm.sh
+: ${RCM_LIB:=$(dirname "$0")/../share/rcm}
+. "$RCM_LIB/rcm.sh"
 
 destination() {
-  local dotfiles_dir=$1
+  local dotfiles_dir="$1"
   local dotless=$2
   local in_host=$3
-  local tag=$4
+  local tag="$4"
 
   if [ "x$tag" != "x" ]; then
-    echo $dotfiles_dir/tag-$tag
+    echo "$dotfiles_dir/tag-$tag"
   elif [ $in_host = 1 ]; then
-    echo $dotfiles_dir/host-$HOSTNAME
+    echo "$dotfiles_dir/host-$HOSTNAME"
   else
-    echo $dotfiles_dir
+    echo "$dotfiles_dir"
   fi
 }
 
@@ -46,11 +46,11 @@ while getopts ChSsVvqot:d: opt; do
   case "$opt" in
     C) always_copy=1 ;;
     h) show_help ;;
-    t) tag=$OPTARG ;;
+    t) tag="$OPTARG" ;;
     v) verbosity=$(($verbosity + 1)) ;;
     q) verbosity=$(($verbosity - 1)) ;;
     o) in_host=1 ;;
-    d) DOTFILES_DIR=$OPTARG ;;
+    d) DOTFILES_DIR="$OPTARG" ;;
     V) version=1 ;;
     S) force_symlink=1 ;;
     s) force_symlink=0 ;;
@@ -72,17 +72,17 @@ files=$@
 
 if [ $force_symlink -eq 1 ]; then
   for file in $files; do
-    dedotted=`de_dot $file`
+    dedotted="$(de_dot "$file")"
     INSTALL="$INSTALL -S $dedotted"
   done
 fi
 
 for file in $files; do
-  dotless=`de_dot $file`
-  dest=`destination $DOTFILES_DIR $dotless $in_host $tag`
-  mkdir -p $dest/`dirname $dotless`
+  dotless="$(de_dot "$file")"
+  dest="$(destination "$DOTFILES_DIR" "$dotless" $in_host "$tag")"
+  mkdir -p "$dest/$(dirname "$dotless")"
   $PRINT "Moving..."
-  $MV $file $dest/$dotless
+  $MV "$file" "$dest/$dotless"
   $PRINT "Linking..."
-  $INSTALL -d $DOTFILES_DIR -t ${tag:--} $dotless
+  $INSTALL -d "$DOTFILES_DIR" -t "${tag:--}" "$dotless"
 done

--- a/bin/rcdn
+++ b/bin/rcdn
@@ -1,20 +1,20 @@
 #!/bin/sh
 
-: ${RCM_LIB:=`dirname $0`/../share/rcm}
-. $RCM_LIB/rcm.sh
+: ${RCM_LIB:=$(dirname "$0")/../share/rcm}
+. "$RCM_LIB/rcm.sh"
 
 remove_link() {
-  local dest=$1
-  local original=$2
-  local sigil=$3
+  local dest="$1"
+  local original="$2"
+  local sigil="$3"
 
-  if [ x$dest = "x/" ]; then
+  if [ "x$dest" = "x/" ]; then
     $VERBOSE "not a symlink, skipping: $original"
-  elif [ -L $dest -o "x$sigil" = "xX" ]; then
-    $RM -rf $dest
-    rmdir -p `dirname $original` 2>/dev/null
+  elif [ -L "$dest" -o "x$sigil" = "xX" ]; then
+    $RM -rf "$dest"
+    rmdir -p "$(dirname "$original")" 2>/dev/null
   else
-    remove_link `dirname $dest` $original
+    remove_link "$(dirname "$dest")" "$original"
   fi
 }
 
@@ -57,9 +57,9 @@ handle_command_line() {
 
   handle_common_flags rcup $version $verbosity
 
-  tags=${arg_tags:-$TAGS}
-  dotfiles_dirs=${dotfiles_dirs:-$DOTFILES_DIRS}
-  files=$@
+  tags="${arg_tags:-$TAGS}"
+  dotfiles_dirs="${dotfiles_dirs:-$DOTFILES_DIRS}"
+  files="$@"
   RUN_HOOKS=$run_hooks
 
   for tag in $tags; do
@@ -84,20 +84,20 @@ handle_command_line() {
 
 LS_ARGS=-F
 
-handle_command_line $*
+handle_command_line $@
 : ${DOTFILES_DIRS:=$DOTFILES_DIRS $DEFAULT_DOTFILES_DIR}
 
 run_hooks pre down
 
-for dest_and_src in `lsrc $LS_ARGS`; do
+for dest_and_src in $(lsrc $LS_ARGS); do
   saved_ifs=$IFS
   IFS=:
   set $dest_and_src
   IFS=$saved_ifs
-  dest=$1
-  sigil=$3
+  dest="$1"
+  sigil="$3"
 
-  remove_link $dest $dest $sigil
+  remove_link "$dest" "$dest" "$sigil"
 done
 
 run_hooks post down

--- a/bin/rcup
+++ b/bin/rcup
@@ -1,29 +1,29 @@
 #!/bin/sh
 
-: ${RCM_LIB:=`dirname $0`/../share/rcm}
-. $RCM_LIB/rcm.sh
+: ${RCM_LIB:=$(dirname "$0")/../share/rcm}
+. "$RCM_LIB/rcm.sh"
 
 link_or_copy() {
   $DEBUG "link_or_copy $1"
-  local sigil=$1
+  local sigil="$1"
 
   if [ "x$sigil" = "xX" ]; then
-    echo $CP
+    echo "$CP"
   else
-    echo $LN
+    echo "$LN"
   fi
 }
 
 link_file() {
   local src="$1"
   local dest="$2"
-  local sigil=$3
+  local sigil="$3"
 
   if [ -h "$dest" ]; then
     $RM -f "$dest"
   fi
 
-  action=`link_or_copy $sigil`
+  action="$(link_or_copy "$sigil")"
   $DEBUG "$action $src $dest"
   $action "$src" "$dest"
 }
@@ -31,17 +31,16 @@ link_file() {
 replace_file() {
   local src="$1"
   local dest="$2"
-  local sigil=$3
+  local sigil="$3"
 
   $DEBUG replace_file "$1" "$2" $3
 
-  $RM -rf $dest
-  link_file "$src" "$dest" $sigil
+  $RM -rf "$dest"
+  link_file "$src" "$dest" "$sigil"
 }
 
 is_nested() {
-  echo $1 | sed "s:$DEST_DIR/::" | grep -q /
-  return $?
+  echo "$1" | sed "s:$DEST_DIR/::" | grep -q '/'
 }
 
 is_identical() {
@@ -51,7 +50,7 @@ is_identical() {
 handle_dir() {
   local dest="$1"
 
-  $DEBUG handle_dir $1
+  $DEBUG "handle_dir $1"
 
   dirname "$dest" | xargs $MKDIR -p
 }
@@ -59,29 +58,29 @@ handle_dir() {
 handle_file() {
   local src="$1"
   local dest="$2"
-  local sigil=$3
+  local sigil="$3"
 
-  $DEBUG handle_file $1 $2 $3
+  $DEBUG "handle_file $1 $2 $3"
 
   if [ -e "$dest" ]; then
     if is_identical "$src" "$dest"; then
       $VERBOSE "identical $dest"
     elif [ $REPLACE_ALL -eq 1 ]; then
-      replace_file "$src" "$dest" $sigil
+      replace_file "$src" "$dest" "$sigil"
     else
       $PROMPT "overwrite ${dest}? [ynaq]"
       read overwrite
-      case $overwrite in
+      case "$overwrite" in
         a) REPLACE_ALL=1
-           replace_file "$src" "$dest" $sigil
+           replace_file "$src" "$dest" "$sigil"
            ;;
-        y) replace_file "$src" "$dest" $sigil ;;
+        y) replace_file "$src" "$dest" "$sigil" ;;
         q) exit 1 ;;
         *) $VERBOSE "skipping $dest" ;;
       esac
     fi
   else
-    link_file "$src" "$dest" $sigil
+    link_file "$src" "$dest" "$sigil"
   fi
 }
 
@@ -128,15 +127,15 @@ handle_command_line() {
   shift $(($OPTIND-1))
 
   if [ $always_copy -eq 1 ]; then
-    LN=$CP
+    LN="$CP"
   fi
 
   handle_common_flags rcup $version $verbosity
 
-  tags=${arg_tags:-$TAGS}
-  DOTFILES_DIRS=${dotfiles_dirs:-$DOTFILES_DIRS}
+  tags="${arg_tags:-$TAGS}"
+  DOTFILES_DIRS="${dotfiles_dirs:-$DOTFILES_DIRS}"
   RUN_HOOKS=$run_hooks
-  files=$@
+  files="$@"
 
   for tag in $tags; do
     LS_ARGS="$LS_ARGS -t $tag"
@@ -160,7 +159,7 @@ handle_command_line() {
 
 LS_ARGS=-F
 
-handle_command_line $*
+handle_command_line $@
 : ${DOTFILES_DIRS:=$DOTFILES_DIRS $DEFAULT_DOTFILES_DIR}
 
 run_hooks pre up
@@ -168,19 +167,19 @@ run_hooks pre up
 saved_ifs=$IFS
 IFS='
 '
-for dest_and_src in `lsrc $LS_ARGS`; do
+for dest_and_src in $(lsrc $LS_ARGS); do
   IFS=:
   set $dest_and_src
   IFS=$saved_ifs
   dest="$1"
   src="$2"
-  sigil=$3
+  sigil="$3"
 
   if is_nested "$dest"; then
     handle_dir "$dest"
   fi
 
-  handle_file "$src" "$dest" $sigil
+  handle_file "$src" "$dest" "$sigil"
 done
 
 run_hooks post up

--- a/share/rcm.sh.in
+++ b/share/rcm.sh.in
@@ -3,7 +3,7 @@ VERSION="@PACKAGE_VERSION@"
 #set -x
 
 DEBUG=:
-DEST_DIR=$HOME
+DEST_DIR="$HOME"
 PRINT=echo
 PROMPT=echo_n
 ERROR=echo_error
@@ -12,11 +12,11 @@ MKDIR=mkdir
 LN="ln -s"
 CP="cp -R"
 RM=rm
-DEFAULT_DOTFILES_DIR=$HOME/.dotfiles
+DEFAULT_DOTFILES_DIR="$HOME/.dotfiles"
 MV=mv
 INSTALL=rcup
-ROOT_DIR=$HOME
-HOSTNAME=`hostname | sed -e 's/\..*//'`
+ROOT_DIR="$HOME"
+HOSTNAME="$(hostname | sed -e 's/\..*//')"
 
 unset CDPATH
 
@@ -27,16 +27,16 @@ echo_n() {
 echo_error() {
   local exit_status=$1
   shift
-  echo $* >&2
+  echo "$*" >&2
   exit $exit_status
 }
 
 echo_stderr() {
-  echo $* >&2
+  echo "$*" >&2
 }
 
 is_relative() {
-  echo $1 | grep -vq '^/'
+  echo "$1" | grep -vq '^/'
 }
 
 version() {
@@ -50,12 +50,12 @@ EOV
 }
 
 handle_common_flags() {
-  local prog_name=$1
-  local version=$2
+  local prog_name="$1"
+  local version="$2"
   local verbosity=$3
 
   if [ $version -eq 1 ]; then
-    version $prog_name
+    version "$prog_name"
     exit 0
   elif [ $verbosity -ge 2 ]; then
     DEBUG=echo_stderr
@@ -92,8 +92,8 @@ handle_common_flags() {
 }
 
 handle_metadata_flags() {
-  local arg_tags=$1
-  local dotfiles_dirs=$2
+  local arg_tags="$1"
+  local dotfiles_dirs="$2"
 
   : ${TAGS:=$arg_tags}
   : ${DOTFILES_DIRS:=$dotfiles_dirs}
@@ -107,7 +107,12 @@ run_hooks() {
   $DEBUG "  with DOTFILES_DIRS: $DOTFILES_DIRS"
   local when="$1"
   local direction="$2"
-  local hook_file
+  local hook_file="$dotfiles_dir/hooks/$when-$direction"
+
+  if [ ! -e "$hook_file" ]; then
+    $DEBUG "no $when-$direction hook file, skipping"
+    return 1
+  fi
 
   if [ $RUN_HOOKS -eq 1 ]; then
     for dotfiles_dir in $DOTFILES_DIRS; do
@@ -126,7 +131,7 @@ run_hooks() {
 de_dot() {
   $DEBUG "de_dot $1"
   $DEBUG "  with DEST_DIR: $DEST_DIR"
-  echo $1 | sed -e "s|$DEST_DIR/||" | sed -e 's/^\.//'
+  echo "$1" | sed -e "s|$DEST_DIR/||" | sed -e 's/^\.//'
 }
 
 : ${RCRC:=$HOME/.rcrc}


### PR DESCRIPTION
All variable expansions which may be strings get quotes. Even if we "know" they
have no spaces (like `$sigil`). We still don't fully support spaces, but this
is a bit better.

`$( )` is [POSIX](http://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html#tag_02_06_03). It's more consistent and easier to nest than backticks.

`$PWD` is [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html#tag_08%29) and is preferred over invoking a separate program.

I wanted to make these fixes while they were on my mind, but I won't be able to
do reasonable testing for a bit. Feel free to let this sit until I (or someone)
can report back that I didn't typo something or unintentionally change
behavior.
