### PR TITLE
Correctly set hook_file in run_hooks

### DIFF
--- a/share/rcm.sh.in
+++ b/share/rcm.sh.in
@@ -105,19 +105,20 @@ handle_metadata_flags() {
 run_hooks() {
   $DEBUG "run_hooks $1 $2"
   $DEBUG "  with DOTFILES_DIRS: $DOTFILES_DIRS"
-  local when=$1
-  local direction=$2
-  local hook_file="$dotfiles_dir/hooks/$when-$direction"
-
-  if [ ! -e "$hook_file" ]; then
-    $DEBUG "no $when-$direction hook file, skipping"
-    return 1
-  fi
+  local when="$1"
+  local direction="$2"
+  local hook_file
 
   if [ $RUN_HOOKS -eq 1 ]; then
     for dotfiles_dir in $DOTFILES_DIRS; do
-      $VERBOSE "running $when-$direction hooks for $dotfiles_dir"
-      find "$hook_file" -type f -perm +111 -print -exec {} \;
+      hook_file="$dotfiles_dir/hooks/$when-$direction"
+
+      if [ -e "$hook_file" ]; then
+        $VERBOSE "running $when-$direction hooks for $dotfiles_dir"
+        find "$hook_file" -type f -perm +111 -print -exec {} \;
+      else
+        $DEBUG "no $when-$direction hook present for $dotfiles_dir, skipping"
+      fi
     done
   fi
 }


### PR DESCRIPTION
The code was setting the $hook_file variable to
$dotfiles_dir/hooks/$when-$direction outside of the loop which actually sets
the $dotfiles_dir variable to each of the dotfiles directories being processed
in turn. This would lead to (for example) /hooks/post-up which is not correct.

The fix is to move that logic into the loop.
