### PR TITLE
Fixed hooks not executing under Cygwin

### DIFF
--- a/NEWS.md.in
+++ b/NEWS.md.in
@@ -1,5 +1,6 @@
 rcm (@PACKAGE_VERSION@) unstable; urgency=low
 
+  * BUGFIX: Cygwin now executes hooks (Daniel Watson).
 
  -- Mike Burns <mburns@thoughtbot.com>  Mon, 03 Feb 2014 16:58:33 +0200
 

--- a/man/rcm.7
+++ b/man/rcm.7
@@ -244,6 +244,7 @@ and
 .An "Anton Ilin" Aq Mt anton@ilin.dn.ua
 .An "Caleb Land" Aq Mt caleb@land.fm
 .An "Dan Croak" Aq Mt dan@thoughtbot.com
+.An "Daniel Watson" Aq Mt dbwatson@vectorspace.org
 .An "George Brocklehurst" Aq Mt george@thoughtbot.com
 .An "Jordan Eldredge" Aq Mt jordaneldredge@gmail.com
 .An "Pablo Olmos de Aguilera Corradini" Aq Mt pablo@glatelier.org

--- a/share/rcm.sh.in
+++ b/share/rcm.sh.in
@@ -115,7 +115,7 @@ run_hooks() {
 
       if [ -e "$hook_file" ]; then
         $VERBOSE "running $when-$direction hooks for $dotfiles_dir"
-        find "$hook_file" -type f -perm +111 -print -exec {} \;
+        find "$hook_file" -type f -perm -111 -print -exec {} \;
       else
         $DEBUG "no $when-$direction hook present for $dotfiles_dir, skipping"
       fi


### PR DESCRIPTION
It looks like the -perm mode to find should use a hyphen not a + (see http://pubs.opengroup.org/onlinepubs/9699919799/utilities/find.html).
