### PR TITLE
rcm.sh should not have +x attribute

### DIFF
--- a/share/Makefile.am
+++ b/share/Makefile.am
@@ -1,1 +1,1 @@
-dist_pkgdata_SCRIPTS = rcm.sh
+dist_pkgdata_DATA = rcm.sh


### PR DESCRIPTION
Fixes rpmlint's "script-without-shebang /usr/share/rcm/rcm.sh" warning
