### PR TITLE
Finding hooks is too verbose

### DIFF
--- a/share/rcm.sh.in
+++ b/share/rcm.sh.in
@@ -112,6 +112,7 @@ run_hooks() {
   local when="$1"
   local direction="$2"
   local hook_file
+  local find_opts=
 
   if [ $RUN_HOOKS -eq 1 ]; then
     for dotfiles_dir in $DOTFILES_DIRS; do
@@ -119,7 +120,12 @@ run_hooks() {
 
       if [ -e "$hook_file" ]; then
         $VERBOSE "running $when-$direction hooks for $dotfiles_dir"
-        find "$hook_file" -type f -perm -111 -print -exec {} \;
+
+        if [ x$DEBUG != x: ]; then
+          find_opts=-print
+        fi
+
+        find "$hook_file" -type f -perm -111 $find_opts -exec {} \;
       else
         $DEBUG "no $when-$direction hook present for $dotfiles_dir, skipping"
       fi


### PR DESCRIPTION
There is a `-print` in the `find` that collects the hooks. This causes it to print to stdout. This should only be enabled in verbose (`-v`) mode.
