### PR TITLE
Use a POSIX sh on Solaris

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,10 @@ depcomp
 debian/rcm
 debian/rcm.debhelper.log
 share/rcm.sh
+bin/lsrc
+bin/mkrc
+bin/rcup
+bin/rcdn
 *deb
 NEWS.md
 rcm-*.tar.gz

--- a/bin/lsrc.in
+++ b/bin/lsrc.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!@SHELL@
 
 : ${RCM_LIB:=$(dirname "$0")/../share/rcm}
 . "$RCM_LIB/rcm.sh"

--- a/bin/mkrc.in
+++ b/bin/mkrc.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!@SHELL@
 
 : ${RCM_LIB:=$(dirname "$0")/../share/rcm}
 . "$RCM_LIB/rcm.sh"

--- a/bin/rcdn.in
+++ b/bin/rcdn.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!@SHELL@
 
 : ${RCM_LIB:=$(dirname "$0")/../share/rcm}
 . "$RCM_LIB/rcm.sh"

--- a/bin/rcup.in
+++ b/bin/rcup.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!@SHELL@
 
 : ${RCM_LIB:=$(dirname "$0")/../share/rcm}
 . "$RCM_LIB/rcm.sh"

--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,13 @@ AC_INIT(rcm, 1.2.1, mburns@thoughtbot.com)
 AM_INIT_AUTOMAKE
 
 # Checks for programs.
+case "$host_os" in
+solaris*)
+    AC_PATH_PROGS(POSIX_SHELL, [ksh93 ksh sh])
+    SHELL="$POSIX_SHELL"
+    ;;
+esac
+AC_SUBST([SHELL])
 
 # Checks for libraries.
 
@@ -16,4 +23,4 @@ AM_INIT_AUTOMAKE
 # Checks for library functions.
 
 AM_EXTRA_RECURSIVE_TARGETS([release_build_man_html release_push_man_html release_clean_man_html])
-AC_OUTPUT(Makefile bin/Makefile man/Makefile share/Makefile share/rcm.sh NEWS.md)
+AC_OUTPUT(Makefile bin/Makefile man/Makefile share/Makefile share/rcm.sh NEWS.md bin/lsrc bin/mkrc bin/rcdn bin/rcup)


### PR DESCRIPTION
As described elsewhere[1](http://books.google.se/books?id=Df7P1WyG87sC&pg=PA4&lpg=PA4&dq=solaris+sh+backticks&source=bl&ots=dvSrtqCIEH&sig=srAdFmHcadAjq1HioAIoIa1urUc&hl=en&sa=X&ei=h2YQU97dF6Kj4gS--YHYBA&redir_esc=y#v=onepage&q=solaris%20sh%20backticks&f=false), Solaris' `/bin/sh` is not POSIX, but `/usr/xpg4/bin/sh` is. Change the shebang line in all scripts to use that.

There must be a way to make autotools handle this for us.
