### PR TITLE
Use scutil for hostname on OS X

### DIFF
--- a/share/rcm.sh.in
+++ b/share/rcm.sh.in
@@ -12,7 +12,11 @@ DEFAULT_DOTFILES_DIR="$HOME/.dotfiles"
 MKDIR=mkdir
 INSTALL=rcup
 ROOT_DIR="$HOME"
-HOSTNAME="$(hostname | sed -e 's/\..*//')"
+if command -vp scutil > /dev/null; then
+  HOSTNAME="$(scutil --get ComputerName | tr '[:upper:]' '[:lower:]')"
+else
+  HOSTNAME="$(hostname | sed -e 's/\..*//')"
+fi
 
 ln_v() {
   $VERBOSE "'$1' -> '$2'"


### PR DESCRIPTION
`hostname` can change when using laptops, depending on DHCP setups etc.  A
problem if you travel a lot with your laptop.

On OS X, `scutil --get ComputerName` will return a consistent answer.
