### PR TITLE
Partial fix for finding hook executables

### DIFF
--- a/share/rcm.sh.in
+++ b/share/rcm.sh.in
@@ -125,7 +125,7 @@ run_hooks() {
           find_opts=-print
         fi
 
-        find "$hook_file" -type f -perm -111 $find_opts -exec {} \;
+        find "$hook_file" -type f \( \( -user $USER -perm -100 \) -o -perm -001 \) $find_opts -exec {} \;
       else
         $DEBUG "no $when-$direction hook present for $dotfiles_dir, skipping"
       fi


### PR DESCRIPTION
This allows, at least, more executables to be picked up.

It doesn't pick up group-executable scripts and ignore xattr files but it
should be better than what was there before.

Closes #80
