### PR TITLE
Hostname override

### DIFF
--- a/NEWS.md.in
+++ b/NEWS.md.in
@@ -4,6 +4,8 @@ rcm (@PACKAGE_VERSION@) unstable; urgency=low
     directory. Verbose hidden files for lsrc(1) (Javier López).
   * Allow running mkrc on a relative file and preserve the
     path (Pablo Olmos de Aguilera Corradini).
+  * A flag (-B), and a variable for rcrc(5) (HOSTNAME), for changing the
+    hostname as rcm sees it (Mike Burns).
 
  -- Mike Burns <mburns@thoughtbot.com>  Fri, 28 Mar 2014 16:30:53 +0100
 

--- a/bin/lsrc.in
+++ b/bin/lsrc.in
@@ -227,8 +227,9 @@ handle_command_line() {
   local excludes=
   local includes=
   local symlink_dirs=
+  local hostname=
 
-  while getopts FVqvhI:x:S:t:d: opt; do
+  while getopts FVqvhI:x:B:S:t:d: opt; do
     case "$opt" in
       F) show_sigils=1;;
       h) show_help ;;
@@ -240,11 +241,13 @@ handle_command_line() {
       V) version=1;;
       x) excludes="$excludes $OPTARG";;
       S) symlink_dirs="$symlink_dirs $OPTARG";;
+      B) hostname="$OPTARG";;
     esac
   done
   shift $(($OPTIND-1))
 
   handle_common_flags lsrc $version $verbosity
+  HOSTNAME="$(determine_hostname "$hostname")"
   SHOW_SIGILS=$show_sigils
   TAGS="${arg_tags:-$TAGS}"
   DOTFILES_DIRS="${dotfiles_dirs:-$DOTFILES_DIRS}"

--- a/bin/mkrc.in
+++ b/bin/mkrc.in
@@ -9,6 +9,8 @@ destination() {
   local in_host=$3
   local tag="$4"
 
+  $DEBUG "destination $dotfiles_dir $dotless $in_host $tag"
+
   if [ "x$tag" != "x" ]; then
     echo "$dotfiles_dir/tag-$tag"
   elif [ $in_host = 1 ]; then
@@ -36,13 +38,15 @@ for DOTFILES_DIR in $DOTFILES_DIRS $DEFAULT_DOTFILES_DIR; do
 done
 
 tag=
+hostname=
 verbosity=0
 in_host=0
 version=0
 always_copy=0
 force_symlink=0
+install_args=
 
-while getopts ChSsVvqot:d: opt; do
+while getopts ChSsVvqot:d:B: opt; do
   case "$opt" in
     C) always_copy=1 ;;
     h) show_help ;;
@@ -54,11 +58,17 @@ while getopts ChSsVvqot:d: opt; do
     V) version=1 ;;
     S) force_symlink=1 ;;
     s) force_symlink=0 ;;
+    B)
+      in_host=1
+      hostname="$OPTARG"
+      install_args="-B $hostname"
+      ;;
   esac
 done
 shift $(($OPTIND-1))
 
 handle_common_flags mkrc $version $verbosity
+HOSTNAME="$(determine_hostname "$hostname")"
 
 if [ $in_host -eq 1 -a "x$tag" != "x" ]; then
   $ERROR 1 "Cannot specify both -o and -t"
@@ -88,5 +98,5 @@ for file in $files; do
   $PRINT "Moving..."
   mv_v "$file" "$dest/$dotless"
   $PRINT "Linking..."
-  $INSTALL -d "$DOTFILES_DIR" -t "${tag:--}" "$dotless"
+  $INSTALL -d "$DOTFILES_DIR" -t "${tag:--}" $install_args "$dotless"
 done

--- a/bin/rcdn.in
+++ b/bin/rcdn.in
@@ -37,10 +37,12 @@ handle_command_line() {
   local excludes=
   local includes=
   local symlink_dirs=
+  local hostname=
 
-  while getopts VqvhI:x:S:t:d: opt; do
+  while getopts VqvhI:x:S:t:d:B: opt; do
     case "$opt" in
       h) show_help ;;
+      B) hostname="$OPTARG" ;;
       I) includes="$includes $OPTARG";;
       k) run_hooks=1 ;;
       K) run_hooks=0 ;;
@@ -56,6 +58,7 @@ handle_command_line() {
   shift $(($OPTIND-1))
 
   handle_common_flags rcup $version $verbosity
+  hostname="$(determine_hostname "$hostname")"
 
   tags="${arg_tags:-$TAGS}"
   dotfiles_dirs="${dotfiles_dirs:-$DOTFILES_DIRS}"
@@ -77,7 +80,7 @@ handle_command_line() {
   for symlink_dir in $symlink_dirs; do
     LS_ARGS="$LS_ARGS -S $symlink_dir"
   done
-  LS_ARGS="$LS_ARGS $files"
+  LS_ARGS="$LS_ARGS -B $hostname $files"
 
   $DEBUG "LS_ARGS: $LS_ARGS"
 }

--- a/bin/rcup.in
+++ b/bin/rcup.in
@@ -104,10 +104,12 @@ handle_command_line() {
   local includes=
   local always_copy=0
   local symlink_dirs=
+  local hostname=
   REPLACE_ALL=0
 
-  while getopts CVqvfhikKI:x:S:t:d: opt; do
+  while getopts CVqvfhikKI:x:S:t:d:B: opt; do
     case "$opt" in
+      B) hostname="$OPTARG" ;;
       C) always_copy=1 ;;
       d) dotfiles_dirs="$dotfiles_dirs $OPTARG" ;;
       f) REPLACE_ALL=1 ;;
@@ -132,6 +134,7 @@ handle_command_line() {
   fi
 
   handle_common_flags rcup $version $verbosity
+  hostname="$(determine_hostname "$hostname")"
 
   tags="${arg_tags:-$TAGS}"
   DOTFILES_DIRS="${dotfiles_dirs:-$DOTFILES_DIRS}"
@@ -153,7 +156,7 @@ handle_command_line() {
   for symlink_dir in $symlink_dirs; do
     LS_ARGS="$LS_ARGS -S $symlink_dir"
   done
-  LS_ARGS="$LS_ARGS $files"
+  LS_ARGS="$LS_ARGS -B $hostname $files"
 
   $DEBUG "LS_ARGS: $LS_ARGS"
 }

--- a/man/lsrc.1
+++ b/man/lsrc.1
@@ -12,6 +12,7 @@
 .Op Fl t Ar tag
 .Op Fl x Ar excl_pat
 .Op Fl N Ar excl_pat
+.Op Fl B Ar hostname
 .Op files ...
 .Sh DESCRIPTION
 This program lists all configuration files, both the sources in the
@@ -26,6 +27,11 @@ section, for details on the directory layout.
 It supports these options:
 .
 .Bl -tag -width "-I excl_pat"
+.It Fl B Ar HOSTNAME
+treat
+.Pa host-HOSTNAME
+as the host-specific directory instead of computing it based on the
+computer's hostname
 .It Fl d Ar DIR
 list dotfiles from the DIR. This can be specified multiple times.
 .

--- a/man/mkrc.1
+++ b/man/mkrc.1
@@ -9,6 +9,7 @@
 .Op Fl Cvqo
 .Op Fl t Ar tag
 .Op Fl d Ar dir
+.Op Fl B Ar hostname
 .Ar files ...
 .Sh DESCRIPTION
 This program adds files to your dotfiles directory then installs it
@@ -18,6 +19,9 @@ different source directory.
 It supports these options:
 .
 .Bl -tag -width "-d DIR"
+.It Fl B Ar HOSTNAME
+use the supplied hostname instead of computing one. Implies
+.Fl o .
 .It Fl C
 copy instead of symlinking when installing the rc file back into your
 home directory

--- a/man/rcdn.1
+++ b/man/rcdn.1
@@ -7,6 +7,7 @@
 .Sh SYNOPSIS
 .Nm rcdn
 .Op Fl kKvq
+.Op Fl B Ar hostname
 .Op Fl d Ar dir
 .Op Fl I Ar excl_pat
 .Op Fl t Ar tag
@@ -43,6 +44,10 @@ These hooks are run each time
 is run and therefore must be idempotent.
 .
 .Bl -tag -width "-I EXCL_PAT"
+.It Fl B Ar HOSTNAME
+treat
+.Pa host-HOSTNAME
+as the host-specific directory instead of computing it
 .It Fl d Ar DIR
 remove rc files from the
 .Ar DIR .

--- a/man/rcm.7.mustache
+++ b/man/rcm.7.mustache
@@ -213,6 +213,13 @@ dotfile directories listed in there are often specific to a single
 machine.
 .Pp
 .Dl mkrc -o .rcrc
+.Pp
+If your hostname is difficult to compute, or you otherwise want to use a
+different hostname, you can use the
+.Fl B
+flag.
+.Pp
+.Dl mkrc -B eggplant .rcrc
 .
 .Sh RATIONALE
 The rcm suite was built as an abstraction over the shell, Ruby, Python,

--- a/man/rcrc.5
+++ b/man/rcrc.5
@@ -44,6 +44,12 @@ explained in detail in
 under the section
 .Sx EXCLUDE PATTERN .
 .
+.It Va HOSTNAME
+the hostname for this computer. This is normally computed using the
+.Xr hostname 1
+command, but this command is non-standard and can prove unreliable. The
+.Va HOSTNAME
+variable forces a known hostname.
 .It Va TAGS
 the default tags.
 .
@@ -62,6 +68,7 @@ under the section
 .Dl COPY_ALWAYS="*"
 .Dl DOTFILES_DIRS="/home/mike/.dotfiles /usr/share/dotfiles"
 .Dl EXCLUDES="irbrc *:*emacs* dotfiles:python*"
+.Dl HOSTNAME="eggplant"
 .Dl TAGS="freebsd development email git laptop gmail notmuch"
 .Dl SYMLINK_DIRS="zprezto"
 .Sh SEE ALSO

--- a/man/rcup.1
+++ b/man/rcup.1
@@ -7,6 +7,7 @@
 .Sh SYNOPSIS
 .Nm rcup
 .Op Fl CfikKqv
+.Op Fl B Ar hostname
 .Op Fl d Ar dir
 .Op Fl I Ar excl_pat
 .Op Fl t Ar tag
@@ -25,6 +26,10 @@ for details on the directory layout.
 .Pp
 It supports these options:
 .Bl -tag -width "-x EXCL_PAT"
+.It Fl B Ar HOSTNAME
+treat
+.Pa host-HOSTNAME
+as the host-specific directory instead of computing it
 .It Fl C
 copy the files instead of symlinking them
 .It Fl d Ar DIR

--- a/share/rcm.sh.in
+++ b/share/rcm.sh.in
@@ -12,7 +12,6 @@ DEFAULT_DOTFILES_DIR="$HOME/.dotfiles"
 MKDIR=mkdir
 INSTALL=rcup
 ROOT_DIR="$HOME"
-HOSTNAME="$(hostname | sed -e 's/\..*//')"
 
 ln_v() {
   $VERBOSE "'$1' -> '$2'"
@@ -96,15 +95,16 @@ handle_common_flags() {
   fi
 }
 
-handle_metadata_flags() {
-  local arg_tags="$1"
-  local dotfiles_dirs="$2"
+determine_hostname() {
+  local name="$1"
 
-  : ${TAGS:=$arg_tags}
-  : ${DOTFILES_DIRS:=$dotfiles_dirs}
-
-  $DEBUG "TAGS: $TAGS"
-  $DEBUG "DOTFILES_DIRS: $DOTFILES_DIRS"
+  if [ -n "$name" ]; then
+    echo "$name"
+  elif [ -n "$HOSTNAME" ]; then
+    echo "$HOSTNAME"
+  else
+    echo "$(hostname | sed -e 's/\..*//')"
+  fi
 }
 
 run_hooks() {

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,20 +1,23 @@
 TESTS = \
-  lsrc-dotfiles-dirs.t \
-  lsrc-excludes.t \
-  lsrc-hostname.t \
-  lsrc-sigils.t \
-  lsrc.t \
-  lsrc-tags.t \
-  lsrc-usage.t \
-  mkrc-alternate-dotfiles-dir.t \
-  mkrc-copy-file.t \
-  mkrc-host-file.t \
-  mkrc-simple-output.t \
-  mkrc-tagged-file.t \
-  mkrc-usage.t \
-  rcrc-custom.t \
-  rcrc.t \
-  rcup-link-files.t \
-  rcup-usage.t
+	lsrc-dotfiles-dirs.t \
+	lsrc-excludes.t \
+	lsrc-hostname.t \
+	lsrc-sigils.t \
+	lsrc.t \
+	lsrc-tags.t \
+	lsrc-usage.t \
+	mkrc-alternate-dotfiles-dir.t \
+	mkrc-copy-file.t \
+	mkrc-host-file.t \
+	mkrc-hostname.t \
+	mkrc-simple-output.t \
+	mkrc-tagged-file.t \
+	mkrc-usage.t \
+	rcrc-custom.t \
+	rcrc-hostname.t \
+	rcrc.t \
+	rcup-link-files.t \
+	rcup-hostname.t \
+	rcup-usage.t
 
 LOG_COMPILER = cram

--- a/test/lsrc-hostname.t
+++ b/test/lsrc-hostname.t
@@ -11,3 +11,7 @@ Should include entries that match hostname
   $ lsrc
   /*/.example:/*/.dotfiles/example (glob)
   /*/.h-example:/*/.dotfiles/host-*/h-example (glob)
+
+  $ lsrc -B not-hostname
+  /*/.example:/*/.dotfiles/example (glob)
+  /*/.nh-example:/*/.dotfiles/host-*/nh-example (glob)

--- a/test/mkrc-hostname.t
+++ b/test/mkrc-hostname.t
@@ -1,0 +1,9 @@
+  $ . "$TESTDIR/helper.sh"
+
+Able to override the hostname
+
+  $ touch .example
+
+  $ mkrc -B another_thing .example >/dev/null
+
+  $ assert_linked "$HOME/.example" "$HOME/.dotfiles/host-another_thing/example"

--- a/test/rcrc-custom.t
+++ b/test/rcrc-custom.t
@@ -1,6 +1,6 @@
   $ . "$TESTDIR/helper.sh"
 
-mkrc should accept -r for a custom rcrc
+mkrc should accept a custom rcrc
 
   $ touch .example
   > mkdir .other-dotfiles

--- a/test/rcrc-hostname.t
+++ b/test/rcrc-hostname.t
@@ -1,0 +1,21 @@
+  $ . "$TESTDIR/helper.sh"
+
+The hostname can be set in ~/.rcrc
+
+  $ touch .dotfiles/example
+  > mkdir .dotfiles/host-$(hostname)
+  > touch .dotfiles/host-$(hostname)/h-example
+  > mkdir .dotfiles/host-eggplant_firetruck
+  > touch .dotfiles/host-eggplant_firetruck/nh-example
+  > mkdir .dotfiles/host-haircut_hammer
+  > touch .dotfiles/host-haircut_hammer/nh-example
+
+  $ echo 'HOSTNAME="eggplant_firetruck"' > $HOME/.rcrc
+
+  $ lsrc
+  /*/.example:/*/.dotfiles/example (glob)
+  /*/.nh-example:/*/.dotfiles/host-eggplant_firetruck/nh-example (glob)
+
+  $ lsrc -B haircut_hammer
+  /*/.example:/*/.dotfiles/example (glob)
+  /*/.nh-example:/*/.dotfiles/host-haircut_hammer/nh-example (glob)

--- a/test/rcup-hostname.t
+++ b/test/rcup-hostname.t
@@ -1,0 +1,14 @@
+  $ . "$TESTDIR/helper.sh"
+
+Should create symlinks for files and directories in the hostname
+
+  $ touch .dotfiles/example
+  > mkdir .dotfiles/host-awesome_host/
+  > touch .dotfiles/host-awesome_host/example2
+  > mkdir .dotfiles/host-$(hostname)/
+  > touch .dotfiles/host-$(hostname)/example3
+
+  $ rcup -B awesome_host > /dev/null
+
+  $ assert_linked "$HOME/.example" "$HOME/.dotfiles/example"
+  $ assert_linked "$HOME/.example2" "$HOME/.dotfiles/host-awesome_host/example2"


### PR DESCRIPTION
- Add a `HOSTNAME` variable to rcrc(5), which allows the user to override the hostname.
- Add a command-line flag (`-B`) to every command which allows the user to override the hostname (e.g. `lsrc -B jupiter`, `mkrc -B jupiter .zshrc`).

This Is an attempt to help with #82, but also seems like a useful feature regardless.
