### PR TITLE
Update documentation on usage

### DIFF
--- a/bin/lsrc.in
+++ b/bin/lsrc.in
@@ -212,8 +212,8 @@ is_excluded() {
 show_help() {
   local exit_code=${1:-0}
 
-  $PRINT "Usage: lsrc [-FVqvh] [-I EXCL_PAT] [-x EXCL_PAT] [-N EXCL_PAT ] [-t TAG] [-d DOT_DIR]"
-  $PRINT "see lsrc(1) and rcm(5) for more details"
+  $PRINT "Usage: lsrc [-FhqVv] [-B HOSTNAME] [-d DOT_DIR] [-I EXCL_PAT] [-S EXCL_PAT ] [-t TAG] [-x EXCL_PAT]"
+  $PRINT "see lsrc(1) and rcm(7) for more details"
 
   exit $exit_code
 }

--- a/bin/mkrc.in
+++ b/bin/mkrc.in
@@ -23,8 +23,8 @@ destination() {
 show_help() {
   local exit_code=${1:-0}
 
-  $PRINT "Usage: mkrc [-hvqo] [-t TAG] [-d DIR] FILES ..."
-  $PRINT "see mkrc(1) and rcm(5) for more details"
+  $PRINT "Usage: mkrc [-ChSsVvqo] [-t TAG] [-d DIR] [-B HOSTNAME] FILES ..."
+  $PRINT "see mkrc(1) and rcm(7) for more details"
 
   exit $exit_code
 }

--- a/bin/rcdn.in
+++ b/bin/rcdn.in
@@ -21,8 +21,8 @@ remove_link() {
 show_help() {
   local exit_code=${1:-0}
 
-  $PRINT "Usage: rcdn [-Vqvh] [-I EXCL_PAT] [-x EXCL_PAT] [-t TAG] [-d DOT_DIR]"
-  $PRINT "see rcdn(1) and rcm(5) for more details"
+  $PRINT "Usage: rcdn [-hqVv] [-B HOSTNAME] [-d DOT_DIR] [-I EXCL_PAT] [-S EXCL_PAT] [-t TAG] [-x EXCL_PAT]"
+  $PRINT "see rcdn(1) and rcm(7) for more details"
 
   exit $exit_code
 }

--- a/bin/rcup.in
+++ b/bin/rcup.in
@@ -87,8 +87,8 @@ handle_file() {
 show_help() {
   local exit_code=${1:-0}
 
-  $PRINT "Usage: rcup [-CVqvfhikK] [-I EXCL_PAT] [-x EXCL_PAT] [-t TAG] [-d DOT_DIR]"
-  $PRINT "see rcup(1) and rcm(5) for more details"
+  $PRINT "Usage: rcup [-CfhiKkqVv] [-B HOSTNAME] [-d DOT_DIR] [-I EXCL_PAT] [-S EXCL_PAT] [-t TAG] [-x EXCL_PAT]"
+  $PRINT "see rcup(1) and rcm(7) for more details"
 
   exit $exit_code
 }

--- a/man/lsrc.1
+++ b/man/lsrc.1
@@ -6,13 +6,13 @@
 .Nd show dotfiles files managed by rcm
 .Sh SYNOPSIS
 .Nm lsrc
-.Op Fl Fvq
+.Op Fl FhqVv
+.Op Fl B Ar hostname
 .Op Fl d Ar dir
 .Op Fl I Ar excl_pat
+.Op Fl S Ar excl_pat
 .Op Fl t Ar tag
 .Op Fl x Ar excl_pat
-.Op Fl N Ar excl_pat
-.Op Fl B Ar hostname
 .Op files ...
 .Sh DESCRIPTION
 This program lists all configuration files, both the sources in the
@@ -52,6 +52,9 @@ and
 .Va SYMLINK_DIRS ,
 respectively.
 .
+.It Fl h
+show usage instructions.
+.
 .It Fl I Ar excl_pat
 include the files that match the given pattern. This is applied after
 any
@@ -71,6 +74,9 @@ pattern to prevent the shell from swallowing the glob.
 .
 .It Fl t Ar TAG
 list dotfiles according to TAG
+.
+.It Fl V
+show the version number.
 .
 .It Fl v
 increase verbosity. This can be repeated for extra verbosity.

--- a/man/mkrc.1
+++ b/man/mkrc.1
@@ -6,7 +6,7 @@
 .Nd bless files into a dotfile managed by rcm
 .Sh SYNOPSIS
 .Nm mkrc
-.Op Fl Cvqo
+.Op Fl ChoqSsVv
 .Op Fl t Ar tag
 .Op Fl d Ar dir
 .Op Fl B Ar hostname
@@ -28,10 +28,15 @@ home directory
 .It Fl d Ar DIR
 install dotfiles under the specified directory. This can be specified
 multiple times.
+.It Fl h
+show usage instructions.
 .It Fl o
 install dotfiles into the host-specific directory
 .It Fl q
 decrease verbosity
+.It Fl S
+treat the specified rc files as files to be symlinked, even if they are
+directories
 .It Fl s
 if the rc file is a file, symlink it; otherwise, make a directory
 structure as described in
@@ -39,13 +44,12 @@ structure as described in
 in the section
 .Sx ALGORITHM .
 This is the default.
-.It Fl S
-treat the specified rc files as files to be symlinked, even if they are
-directories
 .It Fl t Ar TAG
 install dotfiles according to tag
 .It Fl v
 increase verbosity. This can be repeated for extra verbosity.
+.It Fl V
+show the version number.
 .El
 .Sh ENVIRONMENT
 .Bl -tag -width ".Ev RCRC"

--- a/man/rcdn.1
+++ b/man/rcdn.1
@@ -6,10 +6,11 @@
 .Nd remove dotfiles as managed by rcm
 .Sh SYNOPSIS
 .Nm rcdn
-.Op Fl kKvq
+.Op Fl hqVv
 .Op Fl B Ar hostname
 .Op Fl d Ar dir
 .Op Fl I Ar excl_pat
+.Op Fl S Ar excl_pat
 .Op Fl t Ar tag
 .Op Fl x Ar excl_pat
 .Op Ar files ...
@@ -52,6 +53,8 @@ as the host-specific directory instead of computing it
 remove rc files from the
 .Ar DIR .
 This can be specified multiple times.
+.It Fl h
+show usage instructions.
 .It Fl I Ar EXCL_PAT
 remove rc files that match
 .Ar EXCL_PAT
@@ -63,10 +66,10 @@ This can be repeated with additional patterns. See
 .Xr lsrc 1 ,
 .Sx EXCLUDE PATTERN ,
 for more details.
-.It Fl k
-run pre- and post-hooks. This is the default.
 .It Fl K
 skip pre- and post-hooks
+.It Fl k
+run pre- and post-hooks. This is the default.
 .It Fl q
 decrease verbosity
 .It Fl S Ar EXCL_PAT
@@ -79,6 +82,8 @@ remove dotfiles according to
 .Ar TAG
 .It Fl v
 increase verbosity. This can be repeated for extra verbosity.
+.It Fl V
+show the version number.
 .It Fl x Ar EXCL_PAT
 do not remove rc files that match
 .Ar EXCL_PAT .

--- a/man/rcup.1
+++ b/man/rcup.1
@@ -6,10 +6,11 @@
 .Nd update and install dotfiles managed by rcm
 .Sh SYNOPSIS
 .Nm rcup
-.Op Fl CfikKqv
+.Op Fl CfhiKkqVv
 .Op Fl B Ar hostname
 .Op Fl d Ar dir
 .Op Fl I Ar excl_pat
+.Op Fl S Ar excl_pat
 .Op Fl t Ar tag
 .Op Fl x Ar excl_pat
 .Op Ar files ...
@@ -40,10 +41,8 @@ This can be specified multiple times.
 if the rc file already exists in your home directory but does not match
 the file in your dotfiles directory, remove the rc file then create the
 symlink
-.It Fl i
-if the rc file already exists in your home directory but does not match
-the file in your dotfiles directory, prompt for how to handle it. This
-is the default
+.It Fl h
+show usage instructions.
 .It Fl I Ar EXCL_PAT
 install rc files that match
 .Ar EXCL_PAT
@@ -55,12 +54,16 @@ This can be repeated with additional patterns. See
 .Xr lsrc 1 ,
 .Sx EXCLUDE PATTERN ,
 for more details.
+.It Fl i
+if the rc file already exists in your home directory but does not match
+the file in your dotfiles directory, prompt for how to handle it. This
+is the default
+.It Fl K
+skip pre- and post-hooks
 .It Fl k
 run pre- and post-hooks (see
 .Sx DIRECTORY LAYOUT
 for more details on hooks). This is the default.
-.It Fl K
-skip pre- and post-hooks
 .It Fl S Ar EXCL_PAT
 any rc file that matches
 .Ar EXCL_PAT
@@ -71,6 +74,8 @@ install dotfiles according to
 .Ar TAG
 .It Fl q
 decrease verbosity
+.It Fl V
+show the version number.
 .It Fl v
 increase verbosity. This can be repeated for extra verbosity.
 .It Fl x Ar EXCL_PAT


### PR DESCRIPTION
New flags have accumulated without proper care for the usage
instructions or man pages.

I manually went through each program and verified its usage instruction
against its `getopts`, then I alphabeticalized the usage message.

Based on the usage message, I then verified the synposis in the manpage.
Then, based on the synposis, I alphabeticalized the detailed listing of
the arguments and filled in the missing pieces. The `-h` and `-V`
arguments were missing from all manpages.

In the future we will need to be more careful about this. It would be
good to automate a checker that refuses to build unless the docs have
all the flags mentioned.
