### PR TITLE
Override symlink dirs

### DIFF
--- a/bin/lsrc.in
+++ b/bin/lsrc.in
@@ -54,9 +54,10 @@ show_dir() {
   local exclude_file_globs="$6"
   local include_file_globs="$7"
   local symlink_dirs_file_globs="$8"
+  local mk_dirs_file_globs="$9"
   local dest_path="$(build_path "$dest_dir" "$dir" $dotted)"
 
-  $DEBUG "show_dir $1 $2 $3 $4 $5 $6 $7 $8"
+  $DEBUG "show_dir $1 $2 $3 $4 $5 $6 $7 $8 $9"
 
   $VERBOSE "recurring on $dest_path"
 
@@ -64,7 +65,7 @@ show_dir() {
   for f in *; do
     $DEBUG "handling the file $f"
     next_dir="$(file_join "$dotfiles_subdir" "$dir")"
-    handle_file "$f" "$dest_path" "$dotfiles_dir" "$next_dir" 1 "$exclude_file_globs" "$include_file_globs" "$symlink_dirs_file_globs"
+    handle_file "$f" "$dest_path" "$dotfiles_dir" "$next_dir" 1 "$exclude_file_globs" "$include_file_globs" "$symlink_dirs_file_globs" "$mk_dirs_file_globs"
   done
   popdir
 }
@@ -134,17 +135,18 @@ handle_file() {
   local exclude_file_globs="$6"
   local include_file_globs="$7"
   local symlink_dirs_file_globs="$8"
+  local mk_dirs_file_globs="$9"
 
-  $DEBUG "handle_file $1 $2 $3 $4 $5 $6 $7 $8"
+  $DEBUG "handle_file $1 $2 $3 $4 $5 $6 $7 $8" "$9"
 
   if [ ! -e "$file" ]; then
     $VERBOSE "skipping non-existent file $file"
   elif is_excluded "$file" "$exclude_file_globs" "$include_file_globs"; then
     $VERBOSE "skipping excluded file $file"
-  elif [ -d "$file" ] && is_excluded $file "$symlink_dirs_file_globs"; then
-    show_file "$file" "$dest_dir" "$dotfiles_dir" "$dotfiles_subdir" $dotted "$symlink_dirs_file_globs"
+  elif [ -d "$file" ] && is_excluded "$file" "$symlink_dirs_file_globs" "$mk_dirs_file_globs"; then
+    show_file "$file" "$dest_dir" "$dotfiles_dir" "$dotfiles_subdir" $dotted
   elif [ -d "$file" ]; then
-    show_dir "$file" "$dest_dir" "$dotfiles_dir" "$dotfiles_subdir" $dotted "$exclude_file_globs" "$include_file_globs" "$symlink_dirs_file_globs"
+    show_dir "$file" "$dest_dir" "$dotfiles_dir" "$dotfiles_subdir" $dotted "$exclude_file_globs" "$include_file_globs" "$symlink_dirs_file_globs" "$mk_dirs_file_globs"
   else
     show_file "$file" "$dest_dir" "$dotfiles_dir" "$dotfiles_subdir" $dotted
   fi
@@ -227,9 +229,10 @@ handle_command_line() {
   local excludes=
   local includes=
   local symlink_dirs=
+  local never_symlink_dirs=
   local hostname=
 
-  while getopts :FVqvhI:x:B:S:t:d: opt; do
+  while getopts :FVqvhI:x:B:S:s:t:d: opt; do
     case "$opt" in
       F) show_sigils=1;;
       h) show_help ;;
@@ -241,6 +244,7 @@ handle_command_line() {
       V) version=1;;
       x) excludes="$excludes $OPTARG";;
       S) symlink_dirs="$symlink_dirs $OPTARG";;
+      s) never_symlink_dirs="$never_symlink_dirs $OPTARG";;
       B) hostname="$OPTARG";;
       ?) show_help 64 ;;
     esac
@@ -255,6 +259,7 @@ handle_command_line() {
   EXCLUDES="${excludes:-$EXCLUDES}"
   INCLUDES="${includes:-$INCLUDES}"
   SYMLINK_DIRS="${symlink_dirs:-$SYMLINK_DIRS}"
+  MK_DIRS="${never_symlink_dirs:-$MK_DIRS}"
   FILES="$@"
 
   $DEBUG "TAGS: $TAGS"
@@ -273,6 +278,9 @@ $DEBUG "COPY_ALWAYS: $COPY_ALWAYS"
 
 : ${SYMLINK_DIRS:=""}
 $DEBUG "SYMLINK_DIRS: $SYMLINK_DIRS"
+
+: ${MK_DIRS:=""}
+$DEBUG "MK_DIRS: $MK_DIRS"
 
 relative_root_dir="$PWD"
 
@@ -293,6 +301,8 @@ for DOTFILES_DIR in $DOTFILES_DIRS; do
   include_file_globs="$(dotfiles_dir_excludes "$DOTFILES_DIR" "$INCLUDES")"
   symlink_dirs_file_globs="$(dotfiles_dir_excludes "$DOTFILES_DIR" "$SYMLINK_DIRS")"
   $DEBUG "symlink_dirs_file_globs: $symlink_dirs_file_globs"
+  mk_dirs_file_globs=$(dotfiles_dir_excludes "$DOTFILES_DIR" "$MK_DIRS")
+  $DEBUG "mk_dirs_file_globs: $mk_dirs_file_globs"
 
   cd "$DOTFILES_DIR"
   DIR_STACK=":$DOTFILES_DIR"
@@ -302,7 +312,7 @@ for DOTFILES_DIR in $DOTFILES_DIRS; do
       continue
     fi
 
-    handle_file "$file" "$DEST_DIR" "$DOTFILES_DIR" . 0 "$exclude_file_globs" "$include_file_globs" "$symlink_dirs_file_globs"
+    handle_file "$file" "$DEST_DIR" "$DOTFILES_DIR" . 0 "$exclude_file_globs" "$include_file_globs" "$symlink_dirs_file_globs" "$mk_dirs_file_globs"
   done
 
   cd "$DOTFILES_DIR"
@@ -311,7 +321,7 @@ for DOTFILES_DIR in $DOTFILES_DIRS; do
   if [ -d "$host_files" ]; then
     pushdir "$(basename "$host_files")"
     for file in ${FILES:-*}; do
-      handle_file "$file" "$DEST_DIR" "$host_files" . 0 "$exclude_file_globs" "$include_file_globs" "$symlink_dirs_file_globs"
+      handle_file "$file" "$DEST_DIR" "$host_files" . 0 "$exclude_file_globs" "$include_file_globs" "$symlink_dirs_file_globs" "$mk_dirs_file_globs"
     done
     popdir
   fi
@@ -323,7 +333,7 @@ for DOTFILES_DIR in $DOTFILES_DIRS; do
       pushdir "$(basename "tag-$tag")"
       for file in ${FILES:-*}; do
         $DEBUG "TAG: $tag, exclude_file_globs: $exclude_file_globs"
-        handle_file "$file" "$DEST_DIR" "$DOTFILES_DIR/tag-$tag" . 0 "$exclude_file_globs" "$include_file_globs" "$symlink_dirs_file_globs"
+        handle_file "$file" "$DEST_DIR" "$DOTFILES_DIR/tag-$tag" . 0 "$exclude_file_globs" "$include_file_globs" "$symlink_dirs_file_globs" "$mk_dirs_file_globs"
       done
       popdir
     fi

--- a/bin/mkrc.in
+++ b/bin/mkrc.in
@@ -43,7 +43,7 @@ verbosity=0
 in_host=0
 version=0
 always_copy=0
-force_symlink=0
+force_symlink=50
 install_args=
 
 while getopts :ChSsVvqot:d:B: opt; do
@@ -85,6 +85,11 @@ if [ $force_symlink -eq 1 ]; then
   for file in $files; do
     dedotted="$(de_dot "$file")"
     INSTALL="$INSTALL -S $dedotted"
+  done
+elif [ $force_symlink -eq 0 ]; then
+  for file in $files; do
+    dedotted="$(de_dot "$file")"
+    INSTALL="$INSTALL -s $dedotted"
   done
 fi
 

--- a/bin/rcdn.in
+++ b/bin/rcdn.in
@@ -37,9 +37,10 @@ handle_command_line() {
   local excludes=
   local includes=
   local symlink_dirs=
+  local never_symlink_dirs=
   local hostname=
 
-  while getopts :VqvhI:x:S:t:d:B: opt; do
+  while getopts :VqvhI:x:S:s:t:d:B: opt; do
     case "$opt" in
       h) show_help ;;
       B) hostname="$OPTARG" ;;
@@ -48,6 +49,7 @@ handle_command_line() {
       K) run_hooks=0 ;;
       t) arg_tags="$arg_tags $OPTARG" ;;
       S) symlink_dirs="$symlink_dirs $OPTARG";;
+      s) never_symlink_dirs="$never_symlink_dirs $OPTARG";;
       v) verbosity=$(($verbosity + 1));;
       q) verbosity=$(($verbosity - 1));;
       d) dotfiles_dirs="$dotfiles_dirs $OPTARG" ;;
@@ -80,6 +82,9 @@ handle_command_line() {
   done
   for symlink_dir in $symlink_dirs; do
     LS_ARGS="$LS_ARGS -S $symlink_dir"
+  done
+  for never_symlink_dir in $symlink_dirs; do
+    LS_ARGS="$LS_ARGS -s $never_symlink_dir"
   done
   LS_ARGS="$LS_ARGS -B $hostname $files"
 

--- a/bin/rcup.in
+++ b/bin/rcup.in
@@ -104,10 +104,11 @@ handle_command_line() {
   local includes=
   local always_copy=0
   local symlink_dirs=
+  local never_symlink_dirs=
   local hostname=
   REPLACE_ALL=0
 
-  while getopts :CVqvfhikKI:x:S:t:d:B: opt; do
+  while getopts :CVqvfhikKI:x:S:s:t:d:B: opt; do
     case "$opt" in
       B) hostname="$OPTARG" ;;
       C) always_copy=1 ;;
@@ -121,6 +122,7 @@ handle_command_line() {
       q) verbosity=$(($verbosity - 1)) ;;
       t) arg_tags="$arg_tags $OPTARG" ;;
       S) symlink_dirs="$symlink_dirs $OPTARG";;
+      s) never_symlink_dirs="$never_symlink_dirs $OPTARG";;
       v) verbosity=$(($verbosity + 1)) ;;
       V) version=1 ;;
       x) excludes="$excludes $OPTARG" ;;
@@ -156,6 +158,9 @@ handle_command_line() {
   done
   for symlink_dir in $symlink_dirs; do
     LS_ARGS="$LS_ARGS -S $symlink_dir"
+  done
+  for never_symlink_dir in $never_symlink_dirs; do
+    LS_ARGS="$LS_ARGS -s $never_symlink_dir"
   done
   LS_ARGS="$LS_ARGS -B $hostname $files"
 

--- a/man/lsrc.1
+++ b/man/lsrc.1
@@ -11,6 +11,7 @@
 .Op Fl d Ar dir
 .Op Fl I Ar excl_pat
 .Op Fl S Ar excl_pat
+.Op Fl s Ar excl_pat
 .Op Fl t Ar tag
 .Op Fl x Ar excl_pat
 .Op files ...
@@ -71,6 +72,19 @@ symlink the directories that match the given pattern. See
 .Sx EXCLUDE PATTERN
 for more details. This option can be repeated. You may need to quote the
 pattern to prevent the shell from swallowing the glob.
+.
+.It Fl s Ar excl_pat
+if a directory matches the given pattern, recur inside of it instead of
+symlinking. See
+.Sx EXCLUDE PATTERN
+for more details. This is the opposite of the
+.Fl S
+option, and can be used to undo it or the
+.Va SYMLINK_DIRS
+setting in your
+.Xr rcrc 5
+configuration. It can be repeated, and the pattern may need to be quoted to
+protect it from your shell.
 .
 .It Fl t Ar TAG
 list dotfiles according to TAG

--- a/man/rcdn.1
+++ b/man/rcdn.1
@@ -11,6 +11,7 @@
 .Op Fl d Ar dir
 .Op Fl I Ar excl_pat
 .Op Fl S Ar excl_pat
+.Op Fl s Ar excl_pat
 .Op Fl t Ar tag
 .Op Fl x Ar excl_pat
 .Op Ar files ...
@@ -77,6 +78,12 @@ when removing dotfiles, any file that matches
 .Ar EXCL_PAT
 should be treated as a file that was symlinked, even if it is a
 directory. This can be repeated.
+.It Fl s Ar EXCL_PAT
+when removing dotfiles, any directory that matches
+.Ar EXCL_PAT
+should be recurred upon like normal. This is the default, and is the opposite of
+.Fl S .
+This can be repeated.
 .It Fl t Ar TAG
 remove dotfiles according to
 .Ar TAG

--- a/man/rcup.1
+++ b/man/rcup.1
@@ -11,6 +11,7 @@
 .Op Fl d Ar dir
 .Op Fl I Ar excl_pat
 .Op Fl S Ar excl_pat
+.Op Fl s Ar excl_pat
 .Op Fl t Ar tag
 .Op Fl x Ar excl_pat
 .Op Ar files ...
@@ -69,6 +70,14 @@ any rc file that matches
 .Ar EXCL_PAT
 is installed as if it were a file (using a symlink) instead of as if it
 were a directory (by making a directory). This option can be repeated.
+.It Fl s Ar EXCL_PAT
+any file that matches
+.Ar EXCL_PAT
+is installed as normal, in accordance with the
+.Sx ALGORITHM
+section below. This is the opposite of
+.Fl S .
+This option can be repeated.
 .It Fl t Ar TAG
 install dotfiles according to
 .Ar TAG

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -4,6 +4,7 @@ TESTS = \
 	lsrc-hostname.t \
 	lsrc-sigils.t \
 	lsrc.t \
+	lsrc-symlink-dirs.t \
 	lsrc-tags.t \
 	lsrc-usage.t \
 	mkrc-alternate-dotfiles-dir.t \
@@ -11,6 +12,7 @@ TESTS = \
 	mkrc-host-file.t \
 	mkrc-hostname.t \
 	mkrc-simple-output.t \
+	mkrc-symlink-dirs.t \
 	mkrc-tagged-file.t \
 	mkrc-usage.t \
 	rcrc-custom.t \
@@ -18,6 +20,7 @@ TESTS = \
 	rcrc.t \
 	rcup-link-files.t \
 	rcup-hostname.t \
+	rcup-symlink-dirs.t \
 	rcup-usage.t
 
 dist_check_SCRIPTS = $(TESTS)

--- a/test/lsrc-symlink-dirs.t
+++ b/test/lsrc-symlink-dirs.t
@@ -1,0 +1,17 @@
+  $ . "$TESTDIR/helper.sh"
+
+Overrides SYMLINK_DIRS with -s
+
+  $ mkdir -p .dotfiles/eggplant_firetruck/lampshade
+  > touch .dotfiles/eggplant_firetruck/lampshade/bottle
+
+  $ echo 'SYMLINK_DIRS="eggplant_firetruck"' > $HOME/.rcrc
+
+  $ lsrc
+  /*/.eggplant_firetruck:/*/.dotfiles/eggplant_firetruck (glob)
+
+  $ lsrc -s eggplant_firetruck
+  /*/.eggplant_firetruck/lampshade/bottle:/*/.dotfiles/eggplant_firetruck/lampshade/bottle (glob)
+
+  $ lsrc -S eggplant_firetruck -s eggplant_firetruck
+  /*/.eggplant_firetruck/lampshade/bottle:/*/.dotfiles/eggplant_firetruck/lampshade/bottle (glob)

--- a/test/mkrc-symlink-dirs.t
+++ b/test/mkrc-symlink-dirs.t
@@ -1,0 +1,23 @@
+  $ . "$TESTDIR/helper.sh"
+
+Overrides SYMLINK_DIRS with -s
+
+  $ mkdir -p .eggplant_firetruck/lampshade
+  > touch .eggplant_firetruck/lampshade/bottle
+
+  $ mkdir -p .boxing_card
+  > touch .boxing_card/fragrance
+
+  $ echo 'SYMLINK_DIRS="eggplant_firetruck boxing_card"' > $HOME/.rcrc
+
+  $ mkrc -v .boxing_card
+  Moving...
+  '/*/.boxing_card' -> '/*/.dotfiles/boxing_card' (glob)
+  Linking...
+  '/*/.dotfiles/boxing_card' -> '/*/.boxing_card' (glob)
+
+  $ mkrc -vs .eggplant_firetruck
+  Moving...
+  '/*/.eggplant_firetruck' -> '/*/.dotfiles/eggplant_firetruck' (glob)
+  Linking...
+  '/*/.dotfiles/eggplant_firetruck/lampshade/bottle' -> '/*/.eggplant_firetruck/lampshade/bottle' (glob)

--- a/test/rcup-symlink-dirs.t
+++ b/test/rcup-symlink-dirs.t
@@ -1,0 +1,11 @@
+  $ . "$TESTDIR/helper.sh"
+
+Overrides SYMLINK_DIRS with -s
+
+  $ mkdir -p .dotfiles/eggplant_firetruck/lampshade
+  > touch .dotfiles/eggplant_firetruck/lampshade/bottle
+
+  $ echo 'SYMLINK_DIRS="eggplant_firetruck"' > $HOME/.rcrc
+
+  $ rcup -s eggplant_firetruck
+  $ assert_linked "$HOME/.eggplant_firetruck/lampshade/bottle" "$HOME/.dotfiles/eggplant_firetruck/lampshade/bottle"


### PR DESCRIPTION
This adds a `-s` flag, which is the opposite of `-S`: any argument, if it is a directory, is not symlinked but instead recurred down.

Closes #36.
