### PR TITLE
rcdn(1) -K -k

### DIFF
--- a/bin/rcdn.in
+++ b/bin/rcdn.in
@@ -40,7 +40,7 @@ handle_command_line() {
   local never_symlink_dirs=
   local hostname=
 
-  while getopts :VqvhI:x:S:s:t:d:B: opt; do
+  while getopts :VqvhIKk:x:S:s:t:d:B: opt; do
     case "$opt" in
       h) show_help ;;
       B) hostname="$OPTARG" ;;

--- a/man/rcdn.1
+++ b/man/rcdn.1
@@ -6,7 +6,7 @@
 .Nd remove dotfiles as managed by rcm
 .Sh SYNOPSIS
 .Nm rcdn
-.Op Fl hqVv
+.Op Fl hKkqVv
 .Op Fl B Ar hostname
 .Op Fl d Ar dir
 .Op Fl I Ar excl_pat


### PR DESCRIPTION
The rcdn(1) program is all set up to handle the `-K` and `-k` flags,
except those flags were never actually allowed through `getopts`.

Thanks to Mikkel Fahnøe Jørgensen for discovering this.

Closes #93.
