### PR TITLE
Small bugfix regarding #93

### DIFF
--- a/bin/rcdn.in
+++ b/bin/rcdn.in
@@ -40,7 +40,7 @@ handle_command_line() {
   local never_symlink_dirs=
   local hostname=
 
-  while getopts :VqvhIKk:x:S:s:t:d:B: opt; do
+  while getopts :VqvhKkI:x:S:s:t:d:B: opt; do
     case "$opt" in
       h) show_help ;;
       B) hostname="$OPTARG" ;;


### PR DESCRIPTION
`I` needs the colon to take arguments, `k` doesn't. Refer #93
