### PR TITLE
Installation instructions for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,16 @@ Arch Linux:
 
   https://aur.archlinux.org/packages/rcm-git/
 
-Debian-based (including Ubuntu):
+Debian-based:
 
     wget https://thoughtbot.github.io/rcm/debs/rcm_1.2.3-1_all.deb
     sudo dpkg -i rcm_1.2.3-1_all.deb
+    
+Ubuntu (precise or trusty):
+
+    sudo apt-add-repository ppa:martin-frost/thoughtbot-rcm
+    sudo apt-get update
+    sudo apt-get install rcm
 
 openSUSE/RHEL/CentOS: [instructions](http://software.opensuse.org/download.html?project=utilities&package=rcm)
 


### PR DESCRIPTION
Add instructions for how to install rcm on ubuntu using the [~martin-frost/thoughtbot-rcm PPA](https://launchpad.net/~martin-frost/+archive/ubuntu/thoughtbot-rcm)
