### PR TITLE
Fix typo in rcm man page

### DIFF
--- a/man/rcm.7.mustache
+++ b/man/rcm.7.mustache
@@ -78,7 +78,7 @@ Many existing dotfile directories have scripts named
 .Pa install
 or
 .Pa Makefile
-in the directory directory. This will cause a
+in the directory. This will cause a
 .Pa ~/.install
 or
 .Pa ~/.Makefile


### PR DESCRIPTION
The word "directory" was duplicated.
