### PR TITLE
Fix broken mailmap documentation link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ merged.
 Submit a pull request using GitHub. If there is a relevant bug, mention
 it in the commit message (`Fixes #42.`).
 
-[mailmap]: https://github.com/git/git/blob/6a907786af835ac15962be53f1492f2
+[mailmap]: https://github.com/git/git/blob/master/Documentation/mailmap.txt
 
 Testing
 -----

--- a/NEWS.md.in
+++ b/NEWS.md.in
@@ -2,6 +2,7 @@ rcm (@PACKAGE_VERSION@) unstable; urgency=low
 
   * BUGFIX: Use custom function instead of `readlink` to resolve symlinks in
     test helpers (Melissa Xie).
+  * Documentation fixes (Melissa Xie)
   * Show usage information when given bad arguments (Mike Burns).
 
  -- Mike Burns <mburns@thoughtbot.com>  Fri, 09 May 2014 14:17:49 +0200


### PR DESCRIPTION
It was not the full path to the docs, but let's also just refer to the version 
on master.
