### PR TITLE
Manually resolve symlinks in test helpers

### DIFF
--- a/NEWS.md.in
+++ b/NEWS.md.in
@@ -1,5 +1,7 @@
 rcm (@PACKAGE_VERSION@) unstable; urgency=low
 
+  * BUGFIX: Use custom function instead of `readlink` to resolve symlinks in
+    test helpers (Melissa Xie).
   * Show usage information when given bad arguments (Mike Burns).
 
  -- Mike Burns <mburns@thoughtbot.com>  Fri, 09 May 2014 14:17:49 +0200

--- a/test/helper.sh
+++ b/test/helper.sh
@@ -25,9 +25,28 @@ refute() {
   return 0
 }
 
+resolved_path() {
+  local original_path="$1"
+  local actual_path="$original_path"
+  local actual_basename="$(basename "$original_path")"
+
+  cd "$(dirname "$original_path")"
+
+  while [ -L "$actual_basename" ]; do
+    actual_path="$(readlink "$actual_basename")"
+    actual_basename="$(basename "$actual_path")"
+
+    cd "$(dirname "$actual_path")"
+  done
+
+  local current_directory="$(pwd -P)"
+
+  printf "%s/%s\n" "$current_directory" "$actual_basename"
+}
+
 assert_linked() {
   local from="$1" to="$2"
-  local resolved="$(readlink -f "$from")"
+  local resolved="$(resolved_path "$from")"
 
   assert "$from should be a symlink" -h "$from"
   assert "$from should resolve to $to, resolved to $resolved" "$resolved" = "$to"


### PR DESCRIPTION
Mac OS X's `readlink` command does not support the same options as GNU,
FreeBSD, and other operating systems, nor does it support canonicalizing
symlink resolutions.

In place of `readlink`, we're going to borrow [this](http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac) suggested implementation
from the community.
