### PR TITLE
Test hostname

### DIFF
--- a/test/helper.sh
+++ b/test/helper.sh
@@ -9,6 +9,14 @@ export RCM_LIB="$TESTDIR/../share"
 
 mkdir .dotfiles
 
+hostname() {
+  if [ -n "$HOSTNAME" ]; then
+    echo "$HOSTNAME"
+  else
+    command hostname | sed -e 's/\..*//'
+  fi
+}
+
 assert() {
   local msg="$1"; shift
 


### PR DESCRIPTION
The test uses `$(hostname)`, which can produce the FQDN on some systems; however, the
code only uses the host name portion of that. Modify the test to do the
same by defining a `hostname` function that calls the hostname(1)
binary then pipes it through sed(1).

I'd like to get a review from GNU and OS X if possible.
