### PR TITLE
Add setup instructions for contributors

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,6 +1,7 @@
 George Brocklehurst <george@thoughtbot.com> <george.brocklehurst@gmail.com>
 George Brocklehurst <george@thoughtbot.com> <george@georgebrock.com>
 Javier López <linux.kitten@gmail.com> <kitten@openbsdbox>
+Melissa Xie <melissa@thoughtbot.com> <me@melissaxie.com>
 Mike Burns <mburns@thoughtbot.com> <mike@mike-burns.com>
 Pablo Olmos de Aguilera Corradini <pablo@glatelier.org>
 Patrick Brisbin <pat@thoughtbot.com> <pbrisbin@gmail.com>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,14 @@ Contributing
 Overview
 --------
 
+- Fork the repo.
+- Prepare the build system: `./autogen.sh`. (This depends on GNU autoconf and
+  GNU automake.)
+- Configure the package: `./configure`.
+- Make sure the tests pass: `make check`.
+- Make your changes.
 - Update `NEWS.md.in`.
-- Update `.mailmap`.
+- Update `.mailmap` if necessary.
 - Write a test covering your feature or fix.
 - Ensure existing and new tests are passing.
 - Submit a pull request on GitHub.
@@ -22,11 +28,9 @@ We use your name and email address as produced by `git-shortlog(1)`. You
 can change how this is formatted by modifying `.mailmap`. More details
 on that file can be found in the git [Documentation/mailmap.txt][mailmap].
 
-Our test suite is new, and therefore it is not yet mandatory to include 
-tests with pull requests. However, you must ensure that the existing 
-test suite passes with any changes you make. Also, any attempts to add 
-or extend tests will increase the chances of your pull request being 
-merged.
+It is mandatory to include tests with pull requests. You must ensure that the
+existing test suite passes with any changes you make. Also, any attempts to add
+or extend tests will increase the chances of your pull request being merged.
 
 Submit a pull request using GitHub. If there is a relevant bug, mention
 it in the commit message (`Fixes #42.`).
@@ -34,10 +38,10 @@ it in the commit message (`Fixes #42.`).
 [mailmap]: https://github.com/git/git/blob/master/Documentation/mailmap.txt
 
 Testing
------
+-------
 
-The test suite uses [cram][]. It is an integration suite, meaning the 
-programs are exercised from the outside and assertions are made only on 
+The test suite uses [cram][]. It is an integration suite, meaning the
+programs are exercised from the outside and assertions are made only on
 their output or effects.
 
 All tests can be run like so:

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -4,11 +4,9 @@ Developers
 Making a release
 ----------------
 
-1. Bump the version in `configure.ac`, in `AC_INIT`.
+1. Bump the version within the `AC_INIT` macro call in `configure.ac`.
 
-2. Update the build system. This depends on GNU autoconf and GNU automake.
-
-    ./autogen.sh
+2. Update the build system by running: `./autogen.sh`.
 
 3. Build the packages:
 

--- a/NEWS.md.in
+++ b/NEWS.md.in
@@ -2,7 +2,7 @@ rcm (@PACKAGE_VERSION@) unstable; urgency=low
 
   * BUGFIX: Use custom function instead of `readlink` to resolve symlinks in
     test helpers (Melissa Xie).
-  * Documentation fixes (Melissa Xie)
+  * Documentation fixes and updates (Melissa Xie).
   * Show usage information when given bad arguments (Mike Burns).
 
  -- Mike Burns <mburns@thoughtbot.com>  Fri, 09 May 2014 14:17:49 +0200


### PR DESCRIPTION
This clarifies as to how a contributor could get started after pulling down or
forking the repo.

This also removes some trailing spaces and fixes the heading underline.
