### PR TITLE
Add a release script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ test/test-suite.log
 
 # Other generated files
 man/rcm.7
+maint/release

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -8,51 +8,50 @@ Making a release
 
 2. Update the build system by running: `./autogen.sh`.
 
-3. Build the packages:
+3. Build the trivial packages:
 
 This all depends on a `gh-pages` branch:
 
     git branch gh-pages origin/gh-pages
 
+First build the distribution:
+
+    make distcheck
+
 On any system you can build the tarball, Homebrew package, Arch
 PKGBUILD, and tag:
 
-    make release_build_tarball release_build_homebrew release_build_arch \
-	    release_build_tag
+    ./maint/release build tarball rcm-*.tar.gz
+    ./maint/release build homebrew rcm-*.tar.gz
+    ./maint/release build arch rcm-*.tar.gz
+    ./maint/release build tag rcm-*.tar.gz
 
 You need mdocml to tranform the manpages into HTML:
 
-    make release_build_man_html
+    ./maint/release build man_html rcm-*.tar.gz
+
+Once built, you can push it live:
+
+    ./maint/release push tarball rcm-*.tar.gz
+    # ... etc. ...
+
+And once pushed, you should clean up
+
+    ./maint/release clean tarball rcm-*.tar.gz
+    # ... etc. ...
+
+4. Build the Debian package:
 
 Only on Debian systems can you build the Debian package:
 
-    make release_build_deb
+    make NEWS.md
+    ./maint/release build deb rcm-*.tar.gz
+    ./maint/release push deb rcm-*.tar.gz
+    ./maint/release clean deb rcm-*.tar.gz
 
-If you are on a Debian system with mdocml, here is a shortcut:
+5. Contact package maintainers:
 
-    make release_build
-
-From here you can push these:
-
-    make release_push_tarball release_push_homebrew release_push_arch \
-	    release_push_tag release_push_man_html
-    make release_push_deb
-
-Or, all at once:
-
-    make release_push
-
-You can clean individual steps:
-
-    make release_clean_tarball release_clean_homebrew release_clean_arch \
-      release_clean_deb release_clean_tag release_clean_man_html
-
-Or, again, everything at once:
-
-    make release_clean
-
-If you are on a Debian system, have mdocml installed, have an absurd
-amount of trust in the system, and know how to debug it intimately, give
-everything a go:
-
-    make release
+Gentoo   Anton Ilin     <anton@ilin.dn.ua>            0xCB2AA11FEB76CE36
+OpenBSD  Mike Burns     <mike+openbsd@mike-burns.com> 0x3E6761F72846B014
+openSUSE Andrei Dziahel <develop7@develop7.info>      0x58BA3FA4A49D76C2
+Ubuntu   Martin Frost   <frost@ceri.se>               0x98624E2FE507FAF2

--- a/Makefile.am
+++ b/Makefile.am
@@ -2,119 +2,24 @@ AUTOMAKE_OPTIONS = foreign
 SUBDIRS = man share bin test
 EXTRA_DIST = LICENSE README.md NEWS.md
 
-.PHONY: release \
-	release_build release_push release_clean \
-	release_build_tarball release_build_homebrew release_build_arch \
-	release_push_tarball release_push_homebrew release_push_arch \
-	release_clean_tarball release_clean_homebrew release_clean_arch \
-	release_build_deb release_push_deb release_clean_deb release_build_tag \
-	release_push_tag release_clean_tag release_build_man_html \
-	release_push_man_html release_clean_man_html
+.PHONY: release
 
-ORIGIN_URL=$(shell git config --get remote.origin.url)
-CURRENT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
-
-edit_package = sed \
-	-e 's|@PACKAGE[@]|$(PACKAGE)|g' \
-	-e 's|@PACKAGE_VERSION[@]|$(PACKAGE_VERSION)|g' \
-	-e 's|@DIST_ARCHIVES[@]|$(DIST_ARCHIVES)|g' \
-	-e 's|@DIST_SHA[@]|$(DIST_SHA)|g'
-
-release: release_build release_push release_clean
-
-release_build: release_build_tarball release_build_homebrew release_build_arch \
-	release_build_deb release_build_tag release_build_man_html
-
-release_push: release_push_tarball release_push_homebrew release_push_arch \
-	release_push_deb release_push_tag release_push_man_html
-
-release_clean: release_clean_tarball release_clean_homebrew release_clean_arch \
-	release_clean_deb release_clean_tag release_clean_man_html
-
-###### Tarball
-release_build_tarball: Makefile distcheck
-	([ -d gh-pages ] || git clone --branch gh-pages . gh-pages) && \
-		([ -d gh-pages/dist ] || mkdir gh-pages/dist) && \
-		cp $(DIST_ARCHIVES) gh-pages/dist && \
-		cd gh-pages &&\
-			git add dist/$(DIST_ARCHIVES) &&\
-			git commit -m "Release version $(PACKAGE_VERSION) tarball"
-
-release_push_tarball:
-	cd gh-pages &&\
-		git push
-
-release_clean_tarball:
-	rm -rf gh-pages
-	rm -rf $(DIST_ARCHIVES)
-
-###### Homebrew
-release_build_homebrew: DIST_SHA
-	([ -d homebrew-formulae ] || git clone git@github.com:thoughtbot/homebrew-formulae.git homebrew-formulae) && \
-		$(edit_package) homebrew/$(PACKAGE).rb.in > homebrew-formulae/Formula/$(PACKAGE).rb && \
-		cd homebrew-formulae &&\
-		git commit -am "$(PACKAGE): Release version $(PACKAGE_VERSION)"
-
-release_push_homebrew:
-	cd homebrew-formulae &&\
-		git push
-
-release_clean_homebrew:
-	rm -rf homebrew-formulae
-	rm -rf $(DIST_ARCHIVES)
-
-###### Arch
-release_build_arch: DIST_SHA
-	([ -d gh-pages ] || git clone --branch gh-pages . gh-pages) && \
-		([ -d gh-pages/arch ] || mkdir gh-pages/arch) && \
-		$(edit_package) arch/PKGBUILD.in > gh-pages/arch/PKGBUILD &&\
-		cd gh-pages &&\
-			git add arch/PKGBUILD &&\
-			git commit -m "Release version $(PACKAGE_VERSION) Arch package"
-
-release_push_arch:
-	cd gh-pages &&\
-		git push
-
-release_clean_arch:
-	rm -rf gh-pages
-	rm -rf $(DIST_ARCHIVES)
-
-###### Deb
-release_build_deb: NEWS.md DIST_SHA distcheck
-	([ -d deb-build ] || mkdir -p deb-build) && \
-		cp $(DIST_ARCHIVES) deb-build/$(PACKAGE)_$(PACKAGE_VERSION).orig.tar.gz && \
-		tar -C deb-build -xf deb-build/$(PACKAGE)_$(PACKAGE_VERSION).orig.tar.gz && \
-		cp -R debian deb-build/$(PACKAGE)-$(PACKAGE_VERSION) && \
-		cd deb-build/$(PACKAGE)-$(PACKAGE_VERSION) && \
-		dch -d "New upstream release" && dch -r "" && \
-		cp debian/changelog $(abs_srcdir)/debian/changelog && \
-		debuild -us -uc && \
-		cd $(abs_srcdir) && \
-		([ -d gh-pages ] || git clone --branch gh-pages $(ORIGIN_URL) gh-pages) && \
-		([ -d gh-pages/debs ] || mkdir gh-pages/debs) && \
-		cp deb-build/$(PACKAGE)_$(PACKAGE_VERSION)*.deb gh-pages/debs && \
-		cd gh-pages && \
-		git add debs/$(PACKAGE)_$(PACKAGE_VERSION)*deb && \
-		git commit -m "Release version $(PACKAGE_VERSION) for Debian" -- debs/$(PACKAGE)_$(PACKAGE_VERSION)*deb
-
-release_push_deb:
-	cd gh-pages && \
-		git push
-
-release_clean_deb:
-	rm -rf gh-pages
-	rm -rf deb-build
-	rm -rf $(DIST_ARCHIVES)
-
-###### Tag
-release_build_tag:
-	git tag -s v$(PACKAGE_VERSION) -m "Release $(PACKAGE_VERSION)"
-
-release_push_tag:
-	git push origin --tags
-
-release_clean_tag:
-
-DIST_SHA: Makefile distcheck
-	$(eval DIST_SHA := $(shell shasum $(srcdir)/$(DIST_ARCHIVES) | cut -d' ' -f1))
+release: NEWS.md Makefile distcheck
+	maint/release build tarball $(DIST_ARCHIVES)
+	maint/release build homebrew $(DIST_ARCHIVES)
+	maint/release build arch $(DIST_ARCHIVES)
+	maint/release build deb $(DIST_ARCHIVES)
+	maint/release build tag $(DIST_ARCHIVES)
+	maint/release build man_html $(DIST_ARCHIVES)
+	maint/release push tarball $(DIST_ARCHIVES)
+	maint/release push homebrew $(DIST_ARCHIVES)
+	maint/release push arch $(DIST_ARCHIVES)
+	maint/release push deb $(DIST_ARCHIVES)
+	maint/release push tag $(DIST_ARCHIVES)
+	maint/release push man_html $(DIST_ARCHIVES)
+	maint/release clean tarball $(DIST_ARCHIVES)
+	maint/release clean homebrew $(DIST_ARCHIVES)
+	maint/release clean arch $(DIST_ARCHIVES)
+	maint/release clean deb $(DIST_ARCHIVES)
+	maint/release clean tag $(DIST_ARCHIVES)
+	maint/release clean man_html $(DIST_ARCHIVES)

--- a/configure.ac
+++ b/configure.ac
@@ -22,5 +22,4 @@ AC_SUBST([SHELL])
 
 # Checks for library functions.
 
-AM_EXTRA_RECURSIVE_TARGETS([release_build_man_html release_push_man_html release_clean_man_html])
-AC_OUTPUT(Makefile bin/Makefile man/Makefile share/Makefile test/Makefile share/rcm.sh arch/git-PKGBUILD NEWS.md bin/lsrc bin/mkrc bin/rcdn bin/rcup)
+AC_OUTPUT(Makefile bin/Makefile man/Makefile share/Makefile test/Makefile share/rcm.sh arch/git-PKGBUILD NEWS.md bin/lsrc bin/mkrc bin/rcdn bin/rcup maint/release)

--- a/maint/release.in
+++ b/maint/release.in
@@ -1,0 +1,158 @@
+#!/bin/sh
+
+ORIGIN_URL=$(shell git config --get remote.origin.url)
+CURRENT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
+PACKAGE='@PACKAGE@'
+PACKAGE_VERSION='@PACKAGE_VERSION@'
+abs_srcdir='@abs_srcdir@'
+srcdir='@srcdir@'
+abs_top_builddir='@abs_top_builddir@'
+dist_man_MANS='lsrc.1 mkrc.1 rcdn.1 rcup.1 rcrc.5 rcm.7'
+
+edit_package() {
+  sed \
+    -e "s|@PACKAGE[@]|$(PACKAGE)|g" \
+    -e "s|@PACKAGE_VERSION[@]|$(PACKAGE_VERSION)|g" \
+    -e "s|@DIST_ARCHIVES[@]|$(DIST_ARCHIVES)|g" \
+    -e "s|@DIST_SHA[@]|$(DIST_SHA)|g"
+}
+
+# Tarball
+release_build_tarball() {
+  ([ -d gh-pages ] || git clone --branch gh-pages . gh-pages) && \
+    ([ -d gh-pages/dist ] || mkdir gh-pages/dist) && \
+    cp $(DIST_ARCHIVES) gh-pages/dist && \
+    cd gh-pages && \
+      git add dist/$(DIST_ARCHIVES) && \
+      git commit -m "Release version $(PACKAGE_VERSION) tarball"
+}
+
+release_push_tarball() {
+  cd gh-pages && \
+    git push
+}
+
+release_clean_tarball() {
+  rm -rf gh-pages
+  rm -rf $(DIST_ARCHIVES)
+}
+
+# Homebrew
+release_build_homebrew() {
+  ([ -d homebrew-formulae ] || git clone git@github.com:thoughtbot/homebrew-formulae.git homebrew-formulae) && \
+    $(edit_package) homebrew/$(PACKAGE).rb.in > homebrew-formulae/Formula/$(PACKAGE).rb && \
+    cd homebrew-formulae && \
+    git add Formula/$(PACKAGE).rb && \
+    git commit -m "$(PACKAGE): Release version $(PACKAGE_VERSION)"
+}
+
+release_push_homebrew() {
+  cd homebrew-formulae && \
+    git push
+}
+
+release_clean_homebrew() {
+  rm -rf homebrew-formulae
+  rm -rf $(DIST_ARCHIVES)
+}
+
+# Arch
+release_build_arch() {
+  ([ -d gh-pages ] || git clone --branch gh-pages . gh-pages) && \
+    ([ -d gh-pages/arch ] || mkdir gh-pages/arch) && \
+    $(edit_package) arch/PKGBUILD.in > gh-pages/arch/PKGBUILD &&\
+    cd gh-pages &&\
+      git add arch/PKGBUILD &&\
+      git commit -m "Release version $(PACKAGE_VERSION) Arch package"
+}
+
+release_push_arch() {
+  cd gh-pages && \
+    git push
+}
+
+release_clean_arch() {
+  rm -rf gh-pages
+  rm -rf $(DIST_ARCHIVES)
+}
+
+# Deb
+release_build_deb() {
+  ([ -d deb-build ] || mkdir -p deb-build) && \
+    cp $(DIST_ARCHIVES) deb-build/$(PACKAGE)_$(PACKAGE_VERSION).orig.tar.gz && \
+    tar -C deb-build -xf deb-build/$(PACKAGE)_$(PACKAGE_VERSION).orig.tar.gz && \
+    cp -R debian deb-build/$(PACKAGE)-$(PACKAGE_VERSION) && \
+    cd deb-build/$(PACKAGE)-$(PACKAGE_VERSION) && \
+    dch -d "New upstream release" && dch -r "" && \
+    cp debian/changelog $(abs_srcdir)/debian/changelog && \
+    debuild -us -uc && \
+    cd $(abs_srcdir) && \
+    ([ -d gh-pages ] || git clone --branch gh-pages $(ORIGIN_URL) gh-pages) && \
+    ([ -d gh-pages/debs ] || mkdir gh-pages/debs) && \
+    cp deb-build/$(PACKAGE)_$(PACKAGE_VERSION)*.deb gh-pages/debs && \
+    cd gh-pages && \
+    git add debs/$(PACKAGE)_$(PACKAGE_VERSION)*deb && \
+    git commit -m "Release version $(PACKAGE_VERSION) for Debian" -- debs/$(PACKAGE)_$(PACKAGE_VERSION)*deb
+}
+
+release_push_deb() {
+  cd gh-pages && \
+    git push
+}
+
+release_clean_deb() {
+  rm -rf gh-pages
+  rm -rf deb-build
+  rm -rf $(DIST_ARCHIVES)
+}
+
+# Tag
+release_build_tag() {
+  git tag -s v$(PACKAGE_VERSION) -m "Release $(PACKAGE_VERSION)"
+}
+
+release_push_tag() {
+  git push origin --tags
+}
+
+release_clean_tag() {
+}
+
+generate_dist_sha() {
+  export DIST_SHA=$(shasum $(srcdir)/$(DIST_ARCHIVES) | cut -d' ' -f1)
+}
+
+# manpages as HTML
+release_build_man_html() {
+  ([ -d $(abs_top_builddir)/gh-pages ] || git clone --branch gh-pages --single-branch .. $(abs_top_builddir)/gh-pages) && \
+  for i in $(dist_man_MANS); do \
+    mandoc -Thtml -Oman=%N.%S.html $$i > $(abs_top_builddir)/gh-pages/$$i.html ; \
+  done && \
+  cd $(abs_top_builddir)/gh-pages && \
+  cp rcm.7.html index.html && \
+  git add -A && \
+  git commit -m "HTML documentation for $(PACKAGE_VERSION)"
+}
+
+release_push_man_html() {
+  cd $(abs_top_builddir)/gh-pages && \
+    git push -f $(ORIGIN_URL) gh-pages
+}
+
+release_clean_man_html() {
+  rm -rf $(abs_top_builddir)/gh-pages
+}
+
+# Main:
+
+if [ $# < 3 ]; then
+  echo "Usage: release (build|push|clean) (tarball|homebrew|arch|deb|tag|man_html) DIST_ARCHIVES" >&2
+  exit 64
+fi
+
+verb="$1"
+noun="$2"
+DIST_ARCHIVES="$3"
+cmd="release_${verb}_${noun}"
+
+${cmd}

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -1,21 +1,2 @@
+# When changing this you must also change maint/release.in .
 dist_man_MANS = lsrc.1 mkrc.1 rcdn.1 rcup.1 rcrc.5 rcm.7
-
-ORIGIN_URL=$(shell git config --get remote.origin.url)
-
-###### manpages as HTML
-release_build_man_html:
-	([ -d $(abs_top_builddir)/gh-pages ] || git clone --branch gh-pages --single-branch .. $(abs_top_builddir)/gh-pages) && \
-	for i in $(dist_man_MANS); do \
-	  mandoc -Thtml -Oman=%N.%S.html $$i > $(abs_top_builddir)/gh-pages/$$i.html ; \
-	done && \
-	cd $(abs_top_builddir)/gh-pages && \
-	cp rcm.7.html index.html && \
-	git add -A && \
-	git commit -m "HTML documentation for $(PACKAGE_VERSION)"
-
-release_push_man_html:
-	cd $(abs_top_builddir)/gh-pages && \
-		git push -f $(ORIGIN_URL) gh-pages
-
-release_clean_man_html:
-	rm -rf $(abs_top_builddir)/gh-pages


### PR DESCRIPTION
The Makefiles were mostly filled with a complex shell script written in
m4sh. Moving that out into a separate script helps debugging and
compatibility, and in general makes life better.
