### PR TITLE
Add rcup example of adding new rc files

### DIFF
--- a/man/rcm.7.mustache
+++ b/man/rcm.7.mustache
@@ -52,7 +52,7 @@ the directory only contains rc files; and these rc filenames do not
 begin with a period. See the caveats below if this is not you.
 .Bl -enum
 .It
-Dryrun with
+Dry run with
 .Xr lsrc 1 .
 Look for anything unexpected in here, such as
 .Pa ~/.install
@@ -68,10 +68,18 @@ This is likely to do nothing, since your dotfiles already exist.
 .Pp
 .Dl rcup -v
 .It
-When necessary, add new rc files with
+When necessary, add new rc files to the dotfiles directory with
 .Xr mkrc 1 .
 .Pp
 .Dl mkrc ~/.tigrc
+.Pp
+In the other direction, you can use
+.Xr rcup 1
+to create the symlinks from
+.Pa ~/.dotfiles
+to your home directory.
+.Pp
+.Dl rcup tigrc
 .El
 .Ss COMMON PROBLEM: EXISTING INSTALL SCRIPTS
 Many existing dotfile directories have scripts named


### PR DESCRIPTION
It wasn't obvious that you could also use rcup with undotted files to add them
as new rc files.

There was also a typo.

What it looks like now:
![2 tmux 2014-11-24 17-11-22](https://cloud.githubusercontent.com/assets/602470/5174192/06e7c02c-73fd-11e4-85b4-50d9c6726926.jpg)
