### PR TITLE
Improve explanation of DOTFILES_DIRS option

### DIFF
--- a/man/rcrc.5
+++ b/man/rcrc.5
@@ -34,7 +34,9 @@ always copy files that match the listed globs, never symlink them.
 .
 .It Va DOTFILES_DIRS
 the source directories for dotfiles. The first in the list is the
-canonical source. The default value is
+canonical source, to which dotfiles created using
+.Xr mkrc 1
+are installed. The default value is
 .Li ~/.dotfiles
 .
 .It Va EXCLUDES

--- a/man/rcrc.5
+++ b/man/rcrc.5
@@ -34,7 +34,7 @@ always copy files that match the listed globs, never symlink them.
 .
 .It Va DOTFILES_DIRS
 the source directories for dotfiles. The first in the list is the
-canonical source, to which dotfiles created using
+source to which dotfiles created using
 .Xr mkrc 1
 are installed. The default value is
 .Li ~/.dotfiles


### PR DESCRIPTION
The explanation in the man page was vague as to what "canonical source"
meant.
And I'm hoping that what is now written is what is meant (which my experience corroborates).