### PR TITLE
Improve debian build script

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -49,6 +49,10 @@ Only on Debian systems can you build the Debian package:
     ./maint/release push deb rcm-*.tar.gz
     ./maint/release clean deb rcm-*.tar.gz
 
+This will create both a binary and a signed source package.
+
+Source packages go in the `deb-src` directory on the `gh-pages` branch.
+
 5. Contact package maintainers:
 
 Gentoo   Anton Ilin     <anton@ilin.dn.ua>            0xCB2AA11FEB76CE36

--- a/maint/release.in
+++ b/maint/release.in
@@ -119,7 +119,8 @@ release_push_tag() {
   git push origin --tags
 }
 
-release_clean_tag() { :
+release_clean_tag() {
+  :
 }
 
 generate_dist_sha() {

--- a/maint/release.in
+++ b/maint/release.in
@@ -88,9 +88,14 @@ release_build_deb() {
     cd ${abs_top_builddir} && \
     ([ -d gh-pages ] || git clone --branch gh-pages ${ORIGIN_URL} gh-pages) && \
     ([ -d gh-pages/debs ] || mkdir gh-pages/debs) && \
+    ([ -d gh-pages/deb-src ] || mkdir gh-pages/deb-src) && \
     cp deb-build/${PACKAGE}_${PACKAGE_VERSION}*.deb gh-pages/debs && \
+    cp deb-build/${PACKAGE}_${PACKAGE_VERSION}*.dsc gh-pages/deb-src && \
+    cp deb-build/${PACKAGE}_${PACKAGE_VERSION}*.{orig,debian}.tar.gz gh-pages/deb-src && \
     cd gh-pages && \
     git add debs/${PACKAGE}_${PACKAGE_VERSION}*deb && \
+    git add deb-src/${PACKAGE}_${PACKAGE_VERSION}*dsc && \
+    git add deb-src/${PACKAGE}_${PACKAGE_VERSION}*{orig,debian}.tar.gz && \
     git commit -m "Release version ${PACKAGE_VERSION} for Debian" -- debs/${PACKAGE}_${PACKAGE_VERSION}*deb
 }
 

--- a/maint/release.in
+++ b/maint/release.in
@@ -84,7 +84,7 @@ release_build_deb() {
     cp -R debian deb-build/${PACKAGE}-${PACKAGE_VERSION} && \
     cd deb-build/${PACKAGE}-${PACKAGE_VERSION} && \
     dch -d "New upstream release" && dch -r "" && \
-    debuild -us -uc -F && \
+    debuild -F && \
     cd ${abs_top_builddir} && \
     ([ -d gh-pages ] || git clone --branch gh-pages ${ORIGIN_URL} gh-pages) && \
     ([ -d gh-pages/debs ] || mkdir gh-pages/debs) && \

--- a/maint/release.in
+++ b/maint/release.in
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-ORIGIN_URL=$(shell git config --get remote.origin.url)
-CURRENT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
+ORIGIN_URL=$(git config --get remote.origin.url)
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 PACKAGE='@PACKAGE@'
 PACKAGE_VERSION='@PACKAGE_VERSION@'
 abs_srcdir='@abs_srcdir@'
@@ -79,20 +79,20 @@ release_clean_arch() {
 # Deb
 release_build_deb() {
   ([ -d deb-build ] || mkdir -p deb-build) && \
-    cp $(DIST_ARCHIVES) deb-build/$(PACKAGE)_$(PACKAGE_VERSION).orig.tar.gz && \
-    tar -C deb-build -xf deb-build/$(PACKAGE)_$(PACKAGE_VERSION).orig.tar.gz && \
-    cp -R debian deb-build/$(PACKAGE)-$(PACKAGE_VERSION) && \
-    cd deb-build/$(PACKAGE)-$(PACKAGE_VERSION) && \
+    cp ${DIST_ARCHIVES} deb-build/${PACKAGE}_${PACKAGE_VERSION}.orig.tar.gz && \
+    tar -C deb-build -xf deb-build/${PACKAGE}_${PACKAGE_VERSION}.orig.tar.gz && \
+    cp -R debian deb-build/${PACKAGE}-${PACKAGE_VERSION} && \
+    cd deb-build/${PACKAGE}-${PACKAGE_VERSION} && \
     dch -d "New upstream release" && dch -r "" && \
     cp debian/changelog $(abs_srcdir)/debian/changelog && \
     debuild -us -uc && \
     cd $(abs_srcdir) && \
     ([ -d gh-pages ] || git clone --branch gh-pages $(ORIGIN_URL) gh-pages) && \
     ([ -d gh-pages/debs ] || mkdir gh-pages/debs) && \
-    cp deb-build/$(PACKAGE)_$(PACKAGE_VERSION)*.deb gh-pages/debs && \
+    cp deb-build/${PACKAGE}_${PACKAGE_VERSION}*.deb gh-pages/debs && \
     cd gh-pages && \
-    git add debs/$(PACKAGE)_$(PACKAGE_VERSION)*deb && \
-    git commit -m "Release version $(PACKAGE_VERSION) for Debian" -- debs/$(PACKAGE)_$(PACKAGE_VERSION)*deb
+    git add debs/${PACKAGE}_${PACKAGE_VERSION}*deb && \
+    git commit -m "Release version ${PACKAGE_VERSION} for Debian" -- debs/${PACKAGE}_${PACKAGE_VERSION}*deb
 }
 
 release_push_deb() {
@@ -115,7 +115,7 @@ release_push_tag() {
   git push origin --tags
 }
 
-release_clean_tag() {
+release_clean_tag() { :
 }
 
 generate_dist_sha() {
@@ -145,7 +145,7 @@ release_clean_man_html() {
 
 # Main:
 
-if [ $# < 3 ]; then
+if [ $# -lt 3 ]; then
   echo "Usage: release (build|push|clean) (tarball|homebrew|arch|deb|tag|man_html) DIST_ARCHIVES" >&2
   exit 64
 fi

--- a/maint/release.in
+++ b/maint/release.in
@@ -84,10 +84,9 @@ release_build_deb() {
     cp -R debian deb-build/${PACKAGE}-${PACKAGE_VERSION} && \
     cd deb-build/${PACKAGE}-${PACKAGE_VERSION} && \
     dch -d "New upstream release" && dch -r "" && \
-    cp debian/changelog $(abs_srcdir)/debian/changelog && \
-    debuild -us -uc && \
-    cd $(abs_srcdir) && \
-    ([ -d gh-pages ] || git clone --branch gh-pages $(ORIGIN_URL) gh-pages) && \
+    debuild -us -uc -F && \
+    cd ${abs_top_builddir} && \
+    ([ -d gh-pages ] || git clone --branch gh-pages ${ORIGIN_URL} gh-pages) && \
     ([ -d gh-pages/debs ] || mkdir gh-pages/debs) && \
     cp deb-build/${PACKAGE}_${PACKAGE_VERSION}*.deb gh-pages/debs && \
     cd gh-pages && \


### PR DESCRIPTION
The build script for debian was broken. It had shell script bugs (`$()` instead of `${}`, for instance) and tried to run `debuild` in the wrong directory.

I fixed that, and also made it do a full build (`debuild -F`), which means that it will produce both a `.deb` and a `.dsc` file.

Building a source package will help immensely building the ubuntu packages, since they can then be built using the [`backportpackage`](http://manpages.ubuntu.com/manpages/oneiric/man1/backportpackage.1.html) command, instead of me having to build them manually.