### PR TITLE
One bug fix and some minor improvements to rcup

### DIFF
--- a/bin/rcup.in
+++ b/bin/rcup.in
@@ -126,6 +126,18 @@ is_nested() {
   echo "$1" | sed "s:$DEST_DIR/::" | grep -q '/'
 }
 
+is_linked() {
+  local src="$1"
+  local dest="$2"
+
+  if [ -h "$dest" ]; then
+    local link_dest=$(readlink $dest)
+    [ "$link_dest" == "$src" ]
+  else
+    return 1
+  fi  
+}
+
 is_identical() {
   diff -s "$1" "$2" > /dev/null
 }
@@ -148,7 +160,12 @@ handle_file() {
 
   if [ "$generate" -ne 1 -a -e "$dest" ]; then
     if is_identical "$src" "$dest"; then
-      $VERBOSE "identical $dest"
+      if [ "x$sigil" != "xX" ] && ! is_linked "$src" "$dest"; then
+        $VERBOSE "replacing identical but incorrectly linked $dest"
+        replace_file "$src" "$dest" "$sigil"
+      else
+        $VERBOSE "identical $dest"
+      fi
     elif [ $REPLACE_ALL -eq 1 ]; then
       replace_file "$src" "$dest" "$sigil"
     else

--- a/bin/rcup.in
+++ b/bin/rcup.in
@@ -169,16 +169,21 @@ handle_file() {
     elif [ $REPLACE_ALL -eq 1 ]; then
       replace_file "$src" "$dest" "$sigil"
     else
-      $PROMPT "overwrite ${dest}? [ynaq]"
-      read overwrite
-      case "$overwrite" in
-        a) REPLACE_ALL=1
-           replace_file "$src" "$dest" "$sigil"
-           ;;
-        y) replace_file "$src" "$dest" "$sigil" ;;
-        q) exit 1 ;;
-        *) $VERBOSE "skipping $dest" ;;
-      esac
+      overwrite=""
+      while [ -z "$overwrite" -o "$overwrite" == "d" ]
+      do
+        $PROMPT "overwrite ${dest} (d for diff)? [yndaq]"
+        read overwrite
+        case "$overwrite" in
+          d) diff "$src" "$dest" ;;
+          a) REPLACE_ALL=1
+             replace_file "$src" "$dest" "$sigil"
+             ;;
+          y) replace_file "$src" "$dest" "$sigil" ;;
+          q) exit 1 ;;
+          *) $VERBOSE "skipping $dest" ;;
+        esac
+      done
     fi
   else
     link_file "$src" "$dest" "$sigil"

--- a/bin/rcup.in
+++ b/bin/rcup.in
@@ -130,12 +130,7 @@ is_linked() {
   local src="$1"
   local dest="$2"
 
-  if [ -h "$dest" ]; then
-    local link_dest=$(readlink $dest)
-    [ "$link_dest" == "$src" ]
-  else
-    return 1
-  fi  
+  [ -h "$dest" ] && [ "$(readlink "$dest")" = "$src" ]
 }
 
 is_identical() {
@@ -170,7 +165,7 @@ handle_file() {
       replace_file "$src" "$dest" "$sigil"
     else
       overwrite=""
-      while [ -z "$overwrite" -o "$overwrite" == "d" ]
+      while [ -z "$overwrite" -o "$overwrite" = "d" ]
       do
         $PROMPT "overwrite ${dest} (d for diff)? [yndaq]"
         read overwrite

--- a/bin/rcup.in
+++ b/bin/rcup.in
@@ -127,7 +127,7 @@ is_nested() {
 }
 
 is_identical() {
-  diff -q -s "$1" "$2" > /dev/null
+  diff -s "$1" "$2" > /dev/null
 }
 
 handle_dir() {


### PR DESCRIPTION
Three minor changes that I found useful:
- Don't use diff -q since it breaks on some platforms
- Bug fix to avoid a scenario where files were not correctly symlinked if they were already identical to the source but not a symlink
- Add an option to diff non-identical files

Let me know if anything doesn't make sense, I've tested the changes in my own usage.  Thanks for a useful tool!
