### PR TITLE
Changes the priority to: hosts->tags->default

### DIFF
--- a/bin/lsrc.in
+++ b/bin/lsrc.in
@@ -323,21 +323,6 @@ for DOTFILES_DIR in $DOTFILES_DIRS; do
   cd "$DOTFILES_DIR"
   DIR_STACK=":$DOTFILES_DIR"
 
-  for file in ${FILES:-*}; do
-    dotted=0
-    if is_metafile "$file"; then
-      continue
-    fi
-
-    if is_excluded "$file" "$undotted_file_globs" "$never_undotted_file_globs"; then
-      dotted=1
-    fi
-
-    handle_file "$file" "$DEST_DIR" "$DOTFILES_DIR" . "$dotted" "$exclude_file_globs" "$include_file_globs" "$symlink_dirs_file_globs" "$mk_dirs_file_globs"
-  done
-
-  cd "$DOTFILES_DIR"
-
   host_files="$DOTFILES_DIR/host-$HOSTNAME"
   if [ -d "$host_files" ]; then
     pushdir "$(basename "$host_files")"
@@ -369,4 +354,18 @@ for DOTFILES_DIR in $DOTFILES_DIRS; do
     fi
   done
 
+  cd "$DOTFILES_DIR"
+
+  for file in ${FILES:-*}; do
+    dotted=0
+    if is_metafile "$file"; then
+      continue
+    fi
+
+    if is_excluded "$file" "$undotted_file_globs" "$never_undotted_file_globs"; then
+      dotted=1
+    fi
+
+    handle_file "$file" "$DEST_DIR" "$DOTFILES_DIR" . "$dotted" "$exclude_file_globs" "$include_file_globs" "$symlink_dirs_file_globs" "$mk_dirs_file_globs"
+  done
 done

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -8,6 +8,7 @@ TESTS = \
 	lsrc-tags.t \
 	lsrc-usage.t \
 	lsrc-undotted.t \
+	lsrc-host-tags-default.t \
 	mkrc-alternate-dotfiles-dir.t \
 	mkrc-copy-file.t \
 	mkrc-host-file.t \

--- a/test/lsrc-host-tags-default.t
+++ b/test/lsrc-host-tags-default.t
@@ -1,0 +1,17 @@
+  $ . "$TESTDIR/helper.sh"
+
+Hosts override tags override defaults
+
+  $ touch .dotfiles/host-example
+  > touch .dotfiles/tag-example
+  > touch .dotfiles/default-example
+  > mkdir .dotfiles/tag-firetruck
+  > touch .dotfiles/tag-firetruck/host-example
+  > touch .dotfiles/tag-firetruck/tag-example
+  > mkdir .dotfiles/host-eggplant
+  > touch .dotfiles/host-eggplant/host-example
+
+  $ lsrc -B eggplant -t firetruck
+  /*/.host-example:/*/.dotfiles/host-eggplant/host-example (glob)
+  /*/.tag-example:/*/.dotfiles/tag-firetruck/tag-example (glob)
+  /*/.default-example:/*/.dotfiles/default-example (glob)

--- a/test/lsrc-hostname.t
+++ b/test/lsrc-hostname.t
@@ -9,9 +9,9 @@ Should include entries that match hostname
   > touch .dotfiles/host-not-hostname/nh-example
 
   $ lsrc
-  /*/.example:/*/.dotfiles/example (glob)
   /*/.h-example:/*/.dotfiles/host-*/h-example (glob)
+  /*/.example:/*/.dotfiles/example (glob)
 
   $ lsrc -B not-hostname
-  /*/.example:/*/.dotfiles/example (glob)
   /*/.nh-example:/*/.dotfiles/host-*/nh-example (glob)
+  /*/.example:/*/.dotfiles/example (glob)

--- a/test/lsrc-tags.t
+++ b/test/lsrc-tags.t
@@ -9,6 +9,6 @@ Should include entries that match passed tags
   > touch .dotfiles/tag-bar/b-example
 
   $ lsrc -t foo -t bar
-  /*/.example:/*/.dotfiles/example (glob)
   /*/.f-example:/*/.dotfiles/tag-foo/f-example (glob)
   /*/.b-example:/*/.dotfiles/tag-bar/b-example (glob)
+  /*/.example:/*/.dotfiles/example (glob)

--- a/test/rcrc-hostname.t
+++ b/test/rcrc-hostname.t
@@ -13,9 +13,9 @@ The hostname can be set in ~/.rcrc
   $ echo 'HOSTNAME="eggplant_firetruck"' > $HOME/.rcrc
 
   $ lsrc
-  /*/.example:/*/.dotfiles/example (glob)
   /*/.nh-example:/*/.dotfiles/host-eggplant_firetruck/nh-example (glob)
+  /*/.example:/*/.dotfiles/example (glob)
 
   $ lsrc -B haircut_hammer
-  /*/.example:/*/.dotfiles/example (glob)
   /*/.nh-example:/*/.dotfiles/host-haircut_hammer/nh-example (glob)
+  /*/.example:/*/.dotfiles/example (glob)


### PR DESCRIPTION
This changes the order that things are pulled in so that:

1. Hosts take priority over everything.
2. Tags take priority over default.
3. Default takes priority over nothing.

Closes #94

Since issue #94 was just hanging around and I got confused by this again, I decided to just write up the fix.