### PR TITLE
Update Homebrew formula to current recommendations

### DIFF
--- a/homebrew/rcm.rb.in
+++ b/homebrew/rcm.rb.in
@@ -1,7 +1,7 @@
 class Rcm < Formula
-  homepage 'https://thoughtbot.github.io/rcm'
-  url 'https://thoughtbot.github.io/@PACKAGE@/dist/@DIST_ARCHIVES@'
-  sha1 '@DIST_SHA@'
+  homepage "https://thoughtbot.github.io/rcm"
+  url "https://thoughtbot.github.io/@PACKAGE@/dist/@DIST_ARCHIVES@"
+  sha1 "@DIST_SHA@"
 
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",

--- a/homebrew/rcm.rb.in
+++ b/homebrew/rcm.rb.in
@@ -1,6 +1,6 @@
 class Rcm < Formula
-  homepage 'http://thoughtbot.github.io/rcm'
-  url 'http://thoughtbot.github.io/@PACKAGE@/dist/@DIST_ARCHIVES@'
+  homepage 'https://thoughtbot.github.io/rcm'
+  url 'https://thoughtbot.github.io/@PACKAGE@/dist/@DIST_ARCHIVES@'
   sha1 '@DIST_SHA@'
 
   def install

--- a/homebrew/rcm.rb.in
+++ b/homebrew/rcm.rb.in
@@ -1,4 +1,5 @@
 class Rcm < Formula
+  desc "management suite for dotfiles"
   homepage "https://thoughtbot.github.io/rcm"
   url "https://thoughtbot.github.io/@PACKAGE@/dist/@DIST_ARCHIVES@"
   sha1 "@DIST_SHA@"

--- a/homebrew/rcm.rb.in
+++ b/homebrew/rcm.rb.in
@@ -1,5 +1,3 @@
-require 'formula'
-
 class Rcm < Formula
   homepage 'http://thoughtbot.github.io/rcm'
   url 'http://thoughtbot.github.io/@PACKAGE@/dist/@DIST_ARCHIVES@'


### PR DESCRIPTION
This PR updates the Homebrew formula to fix some warnings from `brew audit --strict rcm` brought about by changes in Homebrew.  Specifically:

* Remove `require 'formula'` as this is no longer required. 
* Use HTTPS for GitHub URLs.
* Prefer double quoted strings, as specified by the Homebrew Ruby style guide.
* Add a description field.

`brew audit` also recommends changing the checksum from SHA1 to SHA256, but I haven't done so as it looks like that would break the Arch `PKGBUILD`.