### PR TITLE
make it clear that root privileges are needed for `make install` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This uses the standard GNU autotools, so it's the normal dance:
 
     ./configure && \
     make && \
-    make install
+    sudo make install
 
 For more, see `INSTALL`.
 


### PR DESCRIPTION
Just a small doc fix.

No harm in running with sudo if user already has root privileges.

Thanks