### PR TITLE
Fix hooks so that they are run in the directory they are located (alternative, posix-compliant implementation)

### DIFF
--- a/share/rcm.sh.in
+++ b/share/rcm.sh.in
@@ -126,7 +126,14 @@ run_hooks() {
           find_opts=-print
         fi
 
-        find "$hook_file" -type f \( \( -user $USER -perm -100 \) -o -perm -001 \) $find_opts -exec {} \;
+        # Emulate the non-POSIX-compliant `-execdir` action with `-exec` and a shell one-liner.
+        # The former is however a bit better when it comes to security. On the other hand
+        # running these hooks imply some level of trust; surely one doesn't clone somebody
+        # else's dotfiles repository without reviewing the hooks before doing an `rcup`?
+        find "$hook_file" -type f \( \( -user $USER -perm -100 \) -o -perm -001 \) \
+          -exec \
+            sh -c 'cd "`dirname $1`" && ./"`basename $1`"' arg0 '{}' \
+            \;
       else
         $DEBUG "no $when-$direction hook present for $dotfiles_dir, skipping"
       fi

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -27,7 +27,9 @@ TESTS = \
 	rcup-symlink-dirs.t \
 	rcup-usage.t \
 	rcdn-hooks.t \
-	rcup-hooks.t
+	rcdn-hooks-run-in-situ.t \
+	rcup-hooks.t \
+	rcup-hooks-run-in-situ.t
 
 
 dist_check_SCRIPTS = $(TESTS)

--- a/test/rcdn-hooks-run-in-situ.t
+++ b/test/rcdn-hooks-run-in-situ.t
@@ -1,0 +1,28 @@
+  $ . "$TESTDIR/helper.sh"
+
+Use a pre-generated UUID in a filename to make sure the filename is unique to this test
+and also that the pre-down hook has found the right directory having found this file.
+
+  $ uniquish_file_prefix='test-hooks-run-in-situ-'
+  > uuid='5b811e03-5977-40e6-80ef-dd6c35013e56'
+  > uniquish_file=${uniquish_file_prefix}${uuid}
+
+Pre-down and post-down hooks should run by default. More importantly the hooks\' cwd should
+be the directory where they are situated. We test this by trying to find $uniquish_file.
+
+  $ touch .dotfiles/$uniquish_file
+  > mkdir -p .dotfiles/hooks/pre-down .dotfiles/hooks/post-down
+  > touch .dotfiles/hooks/pre-down/00-test.sh .dotfiles/hooks/post-down/00-test.sh
+  > chmod +x .dotfiles/hooks/pre-down/00-test.sh .dotfiles/hooks/post-down/00-test.sh
+
+  $ echo "echo ../../${uniquish_file_prefix}* > /tmp/test-$uuid" > .dotfiles/hooks/pre-down/00-test.sh
+  > echo "cat /tmp/test-$uuid; rm /tmp/test-$uuid" > .dotfiles/hooks/post-down/00-test.sh
+
+  $ rcdn
+  ../../test-hooks-run-in-situ-5b811e03-5977-40e6-80ef-dd6c35013e56
+
+Ensure that hooks run when output of lsrc is non-empty
+  $ touch .dotfiles/testrc
+  > rcup
+  > rcdn
+  ../../test-hooks-run-in-situ-5b811e03-5977-40e6-80ef-dd6c35013e56

--- a/test/rcup-hooks-run-in-situ.t
+++ b/test/rcup-hooks-run-in-situ.t
@@ -1,0 +1,27 @@
+  $ . "$TESTDIR/helper.sh"
+
+Use a pre-generated UUID in a filename to make sure the filename is unique to this test
+and also that the pre-up hook has found the right directory having found this file.
+
+  $ uniquish_file_prefix='test-hooks-run-in-situ-'
+  > uuid='820a557b-1acb-4e86-8c5b-feb2536b5777'
+  > uniquish_file=${uniquish_file_prefix}${uuid}
+
+Pre-up and post-up hooks should run by default. More importantly the hooks\' cwd should
+be the directory where they are situated. We test this by trying to find $uniquish_file.
+
+  $ touch .dotfiles/$uniquish_file
+  > mkdir -p .dotfiles/hooks/pre-up .dotfiles/hooks/post-up
+  > touch .dotfiles/hooks/pre-up/00-test.sh .dotfiles/hooks/post-up/00-test.sh
+  > chmod +x .dotfiles/hooks/pre-up/00-test.sh .dotfiles/hooks/post-up/00-test.sh
+
+  $ echo "echo ../../${uniquish_file_prefix}* > /tmp/test-$uuid" > .dotfiles/hooks/pre-up/00-test.sh
+  > echo "cat /tmp/test-$uuid; rm /tmp/test-$uuid" > .dotfiles/hooks/post-up/00-test.sh
+
+  $ rcup
+  ../../test-hooks-run-in-situ-820a557b-1acb-4e86-8c5b-feb2536b5777
+
+Ensure that hooks run when output of lsrc is non-empty
+  $ touch .dotfiles/testrc
+  > rcup
+  ../../test-hooks-run-in-situ-820a557b-1acb-4e86-8c5b-feb2536b5777


### PR DESCRIPTION
Calls `find` with the `-print` action instead of `-exec` and pipes the results
to `xargs(1)` which runs a shell one-liner that changes to the hook's directory
and executes the hook with "./" prepended to its basename. These changes allow
hooks to refer to dotfiles with relative paths. For instance we can call
a Makefile two directories up simply with `make -C ../..`.

See issue #148 for a rationale. This is the alternative to the pull request #149, which uses `find(1)` with `-execdir` but is not POSIX compliant. This one, however, I feel is less robust considering the discussion in GNU findutils manual: http://www.gnu.org/software/findutils/manual/html_node/find_html/Security-Considerations-for-xargs.html#Security-Considerations-for-xargs