### PR TITLE
Fix the fact that Solaris 10 lacks readlink(1) & has different grep/diff

### DIFF
--- a/bin/lsrc.in
+++ b/bin/lsrc.in
@@ -118,7 +118,7 @@ show_file() {
     output="$output:$sigil"
   fi
 
-  if echo "$DEST_STACK:" | grep -vq ":$dest_file:"; then
+  if echo "$DEST_STACK:" | grep -v ":$dest_file:" >/dev/null; then
     DEST_STACK="$DEST_STACK:$dest_file"
     $PRINT "$output"
   else
@@ -167,7 +167,7 @@ dotfiles_dir_excludes() {
   $DEBUG "  with excludes: $excludes"
 
   for exclude in $excludes; do
-    if echo "$exclude" | grep -q ':'; then
+    if echo "$exclude" | grep ':' >/dev/null; then
       dotfiles_dir_pat="$(echo "$exclude" | sed 's/:.*//')"
       file_glob="$(echo "$exclude" | sed 's/.*://')"
 

--- a/bin/rcup.in
+++ b/bin/rcup.in
@@ -123,11 +123,11 @@ replace_file() {
 }
 
 is_nested() {
-  echo "$1" | sed "s:$DEST_DIR/::" | grep -q '/'
+  echo "$1" | sed "s:$DEST_DIR/::" | grep '/' >/dev/null
 }
 
 is_identical() {
-  diff -q -s "$1" "$2" > /dev/null
+  diff -c "$1" "$2" > /dev/null 2>&1
 }
 
 handle_dir() {

--- a/share/rcm.sh.in
+++ b/share/rcm.sh.in
@@ -51,7 +51,7 @@ echo_stderr() {
 }
 
 is_relative() {
-  echo "$1" | grep -vq '^/'
+  echo "$1" | grep -v '^/' >/dev/null
 }
 
 version() {

--- a/test/helper.sh
+++ b/test/helper.sh
@@ -35,21 +35,8 @@ refute() {
 
 resolved_path() {
   local original_path="$1"
-  local actual_path="$original_path"
-  local actual_basename="$(basename "$original_path")"
-
-  cd "$(dirname "$original_path")"
-
-  while [ -L "$actual_basename" ]; do
-    actual_path="$(readlink "$actual_basename")"
-    actual_basename="$(basename "$actual_path")"
-
-    cd "$(dirname "$actual_path")"
-  done
-
-  local current_directory="$(pwd -P)"
-
-  printf "%s/%s\n" "$current_directory" "$actual_basename"
+  perl -e \
+    "use Cwd realpath; print realpath(\"$original_path\") . \"\\n\";" 
 }
 
 assert_linked() {


### PR DESCRIPTION
Use a Perl one-liner instead of readlink(1) which is missing on Solaris 10. Using system Perl avoids the need to rely, for instance, on a purpose-built C program that then needs to be compiled, i.e. needs a compiler suite. I think there's a kind of beauty in RCM as a shell program as not all shell environments allow you to install larger pieces of software due of policy or a lack of resources.

Also because /usr/bin/grep and diff(1) don't understand the `-q` option, make
them go quiet by redirecting stdout to /dev/null instead. Fixes #151.