### PR TITLE
Update AUR link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Installation
 
 Arch Linux:
 
-  https://aur.archlinux.org/packages/rcm-git/
+  https://aur.archlinux.org/packages/rcm/
 
 Debian-based:
 


### PR DESCRIPTION
The old package was removed during the AUR migration to a git based platform and now has a new maintainer and package url.