### PR TITLE
Fix faulty flag in the `rcdn` man page

### DIFF
--- a/man/rcdn.1
+++ b/man/rcdn.1
@@ -141,7 +141,7 @@ User configuration file. Defaults to
 .Dl rcdn zshrc
 .Dl rcdn -t python
 .Dl rcdn -d ~/corporate-dotfiles
-.Dl rcdn -e '*:.zshrc'
+.Dl rcdn -x '*:.zshrc'
 .Sh SEE ALSO
 .Xr lsrc 1 ,
 .Xr mkrc 1 ,


### PR DESCRIPTION
There is no `-e` flag available, and `-x` is the flag that is used for
specifying an exclusion pattern.