### PR TITLE
WIP: Find and delete broken symlinks in dotfiles/dotdirs

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -6,3 +6,4 @@ Mike Burns <mburns@thoughtbot.com> <mike@mike-burns.com>
 Pablo Olmos de Aguilera Corradini <pablo@glatelier.org>
 Patrick Brisbin <pat@thoughtbot.com> <pbrisbin@gmail.com>
 Martin Frost <frost@ceri.se> <martin@frost.ws>
+Geoff Harcourt <geoff@thoughtbot.com> <geoff.harcourt@gmail.com>

--- a/Makefile.am
+++ b/Makefile.am
@@ -39,6 +39,8 @@ TESTS = \
 	test/rcup-usage.t \
 	test/rcdn-hooks.t \
 	test/rcdn-hooks-run-in-situ.t \
+	test/rcck.t \
+	test/rcck-usage.t \
 	test/rcup-hooks.t \
 	test/rcup-hooks-run-in-situ.t
 

--- a/bin/rcck.in
+++ b/bin/rcck.in
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+dotteds=$(find $HOME -maxdepth 1 -regex "$HOME\/\..*")
+
+for dotted in $dotteds; do
+  find -L $dotted -type l -exec rm -i {} +
+done

--- a/test/rcck-usage.t
+++ b/test/rcck-usage.t
@@ -1,0 +1,14 @@
+  $ . "$TESTDIR/helper.sh"
+
+-h should output usage information and exit 0
+
+  $ rcck -h
+  Usage: rcck
+  see rcck(1) and rcm(7) for more details
+
+Unsupported options should output usage information and exit EX_USAGE
+
+  $ rcck --version
+  Usage: rcck
+  see rcck(1) and rcm(7) for more details
+  [64]

--- a/test/rcck.t
+++ b/test/rcck.t
@@ -1,0 +1,10 @@
+  $ . "$TESTDIR/helper.sh"
+
+It finds broken symlinks in `$HOME`
+
+  $ touch .example
+  > ln -s .example .example-symlink
+  > rm .example
+
+  $ rcck
+  remove $HOME/.example-symlink?


### PR DESCRIPTION
If users remove dotfiles without using `rcdn(1)` to first clear the
symlinks, they will have broken symlinks that may persist without their
knowledge.

This change adds an `rcck(1)` command that traverses the user's `$HOME`
directory and folders that begin with `.` one level below the home
directory and checks those locations for broken symlinks. The user is
asked for confirmation before deleting each symlink.

Remaining work:
* Tests
* Man page