### PR TITLE
Correct inter-step references in man/rcup.1

### DIFF
--- a/man/rcup.1
+++ b/man/rcup.1
@@ -211,14 +211,14 @@ directory to be created, then
 is symlinked within.
 .
 .It
-Steps (1) and (2) are applied to host-specific files. These are files
+Steps (2) and (3) are applied to host-specific files. These are files
 under a directory named
 .Sm off
 .Pa host- Va $HOSTNAME .
 .Sm on
 .
 .It
-Steps (1) and (2) are applied to tag-specific files. These are files
+Steps (2) and (3) are applied to tag-specific files. These are files
 under directories named
 .Sm off
 .Pa tag- Va $TAG_NAME ,


### PR DESCRIPTION
I'm moderately confident this is an error; Step 1 reads "The pre-up hook is run".