### PR TITLE
RCM looks at ./rcrc if $RCRC not set

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,6 +29,7 @@ TESTS = \
 	test/mkrc-usage.t \
 	test/mkrc-undotted.t \
 	test/rcrc-custom.t \
+	test/rcrc-custom-local.t \
 	test/rcrc-hostname.t \
 	test/rcrc.t \
 	test/rcup-link-files.t \

--- a/share/rcm.sh.in
+++ b/share/rcm.sh.in
@@ -147,7 +147,13 @@ de_dot() {
   echo "$1" | sed -e "s|$DEST_DIR/||" | sed -e 's/^\.//'
 }
 
-: ${RCRC:=$HOME/.rcrc}
+if [ -z "$RCRC" ]; then
+  if [ -r "$PWD/rcrc" ]; then
+    RCRC=$PWD/rcrc
+  else
+    RCRC=$HOME/.rcrc
+  fi
+fi
 
 if [ -r "$RCRC" ]; then
   . "$RCRC"

--- a/test/rcrc-custom-local.t
+++ b/test/rcrc-custom-local.t
@@ -17,3 +17,21 @@ mkrc should prefer ./rcrc to $HOME/.rcrc when RCRC is not set
   '*/.other-dotfiles/example' -> '*/.example' (glob)
 
   $ assert_linked "$HOME/.example" "$HOME/.other-dotfiles/example"
+
+mkrc should prefer RCRC to ./.rcrc when RCRC is set
+
+  $ touch .example
+  > mkdir .other-dotfiles
+  > mkdir hello
+
+  $ echo 'DOTFILES_DIRS="$HOME/.other-dotfiles"' > $HOME/.rcrc
+  $ echo 'DOTFILES_DIRS="$HOME/.bad"' > $HOME/hello/.rcrc
+
+  $ cd hello
+  $ mkrc -v $HOME/.example
+  Moving...
+  '*/.example' -> '*/.other-dotfiles/example' (glob)
+  Linking...
+  '*/.other-dotfiles/example' -> '*/.example' (glob)
+
+  $ assert_linked "$HOME/.example" "$HOME/.other-dotfiles/example"

--- a/test/rcrc-custom-local.t
+++ b/test/rcrc-custom-local.t
@@ -1,0 +1,19 @@
+  $ . "$TESTDIR/helper.sh"
+
+mkrc should prefer ./rcrc to $HOME/.rcrc when RCRC is not set
+
+  $ touch .example
+  > mkdir .other-dotfiles
+
+  $ mkdir hello
+  $ echo 'DOTFILES_DIRS="$HOME/.other-dotfiles"' > $HOME/hello/rcrc
+  $ echo 'DOTFILES_DIRS="$HOME/.bad"' > $HOME/.rcrc
+
+  $ cd hello
+  $ RCRC= mkrc -v $HOME/.example
+  Moving...
+  '*/.example' -> '*/.other-dotfiles/example' (glob)
+  Linking...
+  '*/.other-dotfiles/example' -> '*/.example' (glob)
+
+  $ assert_linked "$HOME/.example" "$HOME/.other-dotfiles/example"


### PR DESCRIPTION
In my dotfiles, I have an `rcrc` file. When I run `rcup`, `rcrc` is not yet in `$HOME/.rcrc` and so it doesn't take effect, so I do `RCRC=rcrc rcup`.

This PR tells rcm to look at `./rcrc` if `$RCRC` is not set. It's a convenience, but a nice one.
