### PR TITLE
Fix relative exclude globs

### DIFF
--- a/NEWS.md.in
+++ b/NEWS.md.in
@@ -1,5 +1,6 @@
 rcm (@PACKAGE_VERSION@) unstable; urgency=low
 
+  * BUGFIX: Relative exclude globs now work (Eric Collins, Mike Burns).
   * BUGFIX: Use $LOGNAME instead of $USER for compatibility (Mike Burns).
   * BUGFIX: rcdn(1) stops at DEST_DIR (Kyle Cook, Mike Burns).
   * BUGFIX: Symlink existing files, even when identical (Graham Bennett).

--- a/bin/lsrc.in
+++ b/bin/lsrc.in
@@ -141,9 +141,9 @@ handle_file() {
 
   if [ ! -e "$file" ]; then
     $VERBOSE "skipping non-existent file $file"
-  elif is_excluded "$file" "$exclude_file_globs" "$include_file_globs"; then
+  elif is_excluded "$dotfiles_subdir/$file" "$exclude_file_globs" "$include_file_globs"; then
     $VERBOSE "skipping excluded file $file"
-  elif [ -d "$file" ] && is_excluded "$file" "$symlink_dirs_file_globs" "$mk_dirs_file_globs"; then
+  elif [ -d "$file" ] && is_excluded "$dotfiles_subdir/$file" "$symlink_dirs_file_globs" "$mk_dirs_file_globs"; then
     show_file "$file" "$dest_dir" "$dotfiles_dir" "$dotfiles_subdir" $dotted
   elif [ -d "$file" ]; then
     show_dir "$file" "$dest_dir" "$dotfiles_dir" "$dotfiles_subdir" $dotted "$exclude_file_globs" "$include_file_globs" "$symlink_dirs_file_globs" "$mk_dirs_file_globs"
@@ -188,6 +188,7 @@ is_excluded() {
   local file="$1"
   local exclude_file_globs="$2"
   local include_file_globs="$3"
+  local base_file="$(basename "$file")"
 
   $DEBUG "is_excluded $file $exclude_file_globs $include_file_globs"
 
@@ -195,20 +196,40 @@ is_excluded() {
     $DEBUG "file: $file"
     $DEBUG "exclude_file_glob: $exclude_file_glob"
 
-    case "$file" in
-      $exclude_file_glob)
-        for include_file_glob in $include_file_globs; do
-          case "$file" in
-            $include_file_glob) return 1;;
-          esac
-        done
+    is_single_excluded "$file" "$exclude_file_glob" "$include_file_globs"
+    ret=$?
+    if [ $ret -eq 0 -o $ret -eq 1 ]; then
+      return $ret
+    fi
 
-        return 0
-        ;;
-    esac
+    is_single_excluded "$base_file" "$exclude_file_glob" "$include_file_globs"
+    ret=$?
+    if [ $ret -eq 0 -o $ret -eq 1 ]; then
+      return $ret
+    fi
   done
 
   return 1
+}
+
+is_single_excluded() {
+  local file="$1"
+  local exclude_file_glob="$2"
+  local include_file_globs="$3"
+
+  case "$file" in
+    $exclude_file_glob)
+      for include_file_glob in $include_file_globs; do
+        case "$file" in
+          $include_file_glob) return 1;;
+        esac
+      done
+
+      return 0
+      ;;
+  esac
+
+  return 2
 }
 
 show_help() {

--- a/man/lsrc.1
+++ b/man/lsrc.1
@@ -1,4 +1,4 @@
-.Dd February 7, 2014
+.Dd December 23, 2016
 .Dt LSRC 1
 .Os
 .Sh NAME
@@ -196,5 +196,4 @@ pattern is unpredictable, so use
 .Fl v
 when dealing with patterns. Specifically, globs may expand at any
 time and remain expanded for the duration of the run, which means they
-cannot be applied more than once. In addition, globs involving
-relative directory names do not work.
+cannot be applied more than once.

--- a/test/lsrc-excludes.t
+++ b/test/lsrc-excludes.t
@@ -18,3 +18,18 @@ Should accept directory:file syntax
   /*/.example:/*/.dotfiles/example (glob)
   /*/.excluded:/*/.dotfiles/excluded (glob)
   /*/.included:/*/.other-dotfiles/included (glob)
+
+Should handle excludes with globs
+
+  $ mkdir -p fresh/hola/chao
+  > touch fresh/hola/chao/wo
+  > touch fresh/hola/chao/nemo
+  > touch fresh/hola/tossala
+  > touch fresh/hola/s
+  > touch fresh/s
+
+  $ lsrc -d fresh -x 'hola/chao/*' -x s
+  /*/.hola/tossala:/*/fresh/hola/tossala (glob)
+
+  $ lsrc -d fresh -x 'hola/chao' -x s
+  /*/.hola/tossala:/*/fresh/hola/tossala (glob)


### PR DESCRIPTION
Pass the dotfiles subdir along with the file to `is_excluded` so that we
can match against it.

Preserve single-file compatibility by looping twice.

Closes #11, #92.