### PR TITLE
Update location of thoughtbot's GPG key

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Arch Linux:
 
 Debian-based:
 
-    wget -qO - https://apt.thoughtbot.com/thoughtbot_apt.gpg.key | sudo apt-key add -
+    wget -qO - https://apt.thoughtbot.com/thoughtbot.gpg.key | sudo apt-key add -
     echo "deb http://apt.thoughtbot.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/thoughtbot.list
     sudo apt-get update
     sudo apt-get install rcm


### PR DESCRIPTION
I think this is right. The repo doesn't contain 1.3.1 so I can't be sure. But it doesn't error after I changed this.