### PR TITLE
Don't rely on bashisms

### DIFF
--- a/bin/mkrc.in
+++ b/bin/mkrc.in
@@ -5,8 +5,8 @@
 
 destination() {
   local dotfiles_dir="$1"
-  local dotless=$2
-  local in_host=$3
+  local dotless="$2"
+  local in_host="$3"
   local tag="$4"
 
   $DEBUG "destination $dotfiles_dir $dotless $in_host $tag"

--- a/bin/rcup.in
+++ b/bin/rcup.in
@@ -136,7 +136,7 @@ is_linked() {
 
   if [ -h "$dest" ]; then
     local link_dest=$(readlink $dest)
-    expr "$link_dest" == "$src" >/dev/null
+    [ "$link_dest" = "$src" ]
   else
     return 1
   fi  

--- a/bin/rcup.in
+++ b/bin/rcup.in
@@ -136,7 +136,7 @@ is_linked() {
 
   if [ -h "$dest" ]; then
     local link_dest=$(readlink $dest)
-    [ "$link_dest" == "$src" ]
+    expr "$link_dest" == "$src" >/dev/null
   else
     return 1
   fi  
@@ -208,7 +208,7 @@ handle_command_line() {
   local never_symlink_dirs=
   local hostname=
   local generate=0
-  local args=$*
+  local args="$*"
   local undotted=
   local never_undotted=
   REPLACE_ALL=0


### PR DESCRIPTION
Fixes issue #200:

```
$ CONFIG_SHELL=/bin/dash ./configure && make check
[...]
============================================================================
Testsuite summary for rcm 1.3.1
============================================================================
# TOTAL: 36
# PASS:  36
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```