### PR TITLE
rcup: handle directory names containing whitespace

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -44,7 +44,8 @@ TESTS = \
 	test/rcdn-hooks-run-in-order.t \
 	test/rcup-hooks.t \
 	test/rcup-hooks-run-in-situ.t \
-	test/rcup-hooks-run-in-order.t
+	test/rcup-hooks-run-in-order.t \
+	test/rcup-spaces.t
 
 dist_check_SCRIPTS = $(TESTS)
 dist_check_DATA = test/helper.sh

--- a/bin/rcup.in
+++ b/bin/rcup.in
@@ -34,7 +34,7 @@ print_generated_preface() {
 #
 #    sh install.sh
 #
-# Environment variables: VERBOSE, CP, LN, MKDIR, RM, DIRNAME, XARGS.
+# Environment variables: VERBOSE, CP, LN, MKDIR, RM, DIRNAME.
 #
 #    env VERBOSE=1 sh install.sh
 #
@@ -52,7 +52,6 @@ print_generated_preface() {
 : \${MKDIR:=/bin/mkdir}
 : \${RM:=/bin/rm}
 : \${DIRNAME:=/usr/bin/dirname}
-: \${XARGS:=/usr/bin/xargs}
 verbose() {
   if [ "\$VERBOSE" -gt 0 ]; then
     echo "\$@"
@@ -73,7 +72,7 @@ handle_file_cp() {
     esac
   fi
   verbose "'\$1' -> '\$2'"
-  \$DIRNAME "\$2" | \$XARGS \$MKDIR -p
+  \$MKDIR -p "\$(\$DIRNAME "\$2")"
   \$CP -R "\$1" "\$2"
 }
 handle_file_ln() {
@@ -91,7 +90,7 @@ handle_file_ln() {
     esac
   fi
   verbose "'\$1' -> '\$2'"
-  \$DIRNAME "\$2" | \$XARGS \$MKDIR -p
+  \$MKDIR -p "\$(\$DIRNAME "\$2")"
   \$LN -sf "\$1" "\$2"
 }
 PREFACE
@@ -145,9 +144,9 @@ is_linked() {
 handle_dir() {
   local dest="$1"
 
-  $DEBUG "handle_dir $1"
+  $DEBUG "handle_dir $dest"
 
-  dirname "$dest" | xargs $MKDIR -p
+  $MKDIR -p "$(dirname "$dest")"
 }
 
 handle_file() {

--- a/test/rcup-spaces.t
+++ b/test/rcup-spaces.t
@@ -1,0 +1,10 @@
+  $ . "$TESTDIR/helper.sh"
+
+Should create symlinks for files in directories with whitespace in their names
+
+  $ mkdir .dotfiles/sub\ dir
+  > touch .dotfiles/sub\ dir/example
+
+  $ rcup >/dev/null
+
+  $ assert_linked "$HOME/.sub dir/example" "$HOME/.dotfiles/sub dir/example"

--- a/test/rcup-standalone.t
+++ b/test/rcup-standalone.t
@@ -12,7 +12,7 @@
   #
   #    sh install.sh
   #
-  # Environment variables: VERBOSE, CP, LN, MKDIR, RM, DIRNAME, XARGS.
+  # Environment variables: VERBOSE, CP, LN, MKDIR, RM, DIRNAME.
   #
   #    env VERBOSE=1 sh install.sh
   #
@@ -30,7 +30,6 @@
   : ${MKDIR:=/bin/mkdir}
   : ${RM:=/bin/rm}
   : ${DIRNAME:=/usr/bin/dirname}
-  : ${XARGS:=/usr/bin/xargs}
   verbose() {
     if [ "$VERBOSE" -gt 0 ]; then
       echo "$@"
@@ -51,7 +50,7 @@
       esac
     fi
     verbose "'$1' -> '$2'"
-    $DIRNAME "$2" | $XARGS $MKDIR -p
+    $MKDIR -p "$($DIRNAME "$2")"
     $CP -R "$1" "$2"
   }
   handle_file_ln() {
@@ -69,7 +68,7 @@
       esac
     fi
     verbose "'$1' -> '$2'"
-    $DIRNAME "$2" | $XARGS $MKDIR -p
+    $MKDIR -p "$($DIRNAME "$2")"
     $LN -sf "$1" "$2"
   }
   handle_file_ln "*eggplant_firetruck/lampshade/bottle" "*.eggplant_firetruck/lampshade/bottle" (glob)


### PR DESCRIPTION
This commit fixes #197.