### PR TITLE
add Gentoo install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ Ubuntu:
     sudo apt-get update
     sudo apt-get install rcm
 
+Gentoo:
+
+    emerge app-admin/rcm
+
 Elsewhere:
 
 This uses the standard GNU autotools, so it's the normal dance:


### PR DESCRIPTION
rcm is now included in the Gentoo portage \o/