### PR TITLE
Set the LOGNAME from whoami

### DIFF
--- a/share/rcm.sh.in
+++ b/share/rcm.sh.in
@@ -13,6 +13,10 @@ MKDIR=mkdir
 INSTALL=rcup
 ROOT_DIR="$HOME"
 
+if [ -z "$LOGNAME" ]; then
+  LOGNAME=$(whoami)
+fi
+
 ln_v() {
   $VERBOSE "'$1' -> '$2'"
   ln -s "$1" "$2"

--- a/test/rcup-hooks.t
+++ b/test/rcup-hooks.t
@@ -9,10 +9,10 @@ Pre-up and post-up hooks should run by default
   $ echo 'echo "example" > /tmp/test' > .dotfiles/hooks/pre-up
   > echo 'cat /tmp/test; rm /tmp/test' > .dotfiles/hooks/post-up
 
-  $ rcup
+  $ /usr/bin/env -i PATH="$PATH" HOME="$HOME" RCRC="$RCRC" RCM_LIB="$RCM_LIB" rcup
   example
 
 Ensure that hooks run when output of lsrc is non-empty
   $ touch .dotfiles/testrc
-  > rcup
+  $ /usr/bin/env -i PATH="$PATH" HOME="$HOME" RCRC="$RCRC" RCM_LIB="$RCM_LIB" rcup
   example


### PR DESCRIPTION
Well, $LOGNAME is defined by POSIX (see
a801c4c58902cae7b835d890487edc39bd7da142) but it's not appearing in
reality under clean environments:

    ~% env -i /bin/bash
    mike:/home/mike$ echo $LOGNAME

    mike:/home/mike$ exit
    ~% env -i /bin/dash
    $ echo $LOGNAME

    $ exit
    ~% env -i /bin/ksh
    $ echo $LOGNAME

    $ exit
    ~% env -i /usr/bin/zsh
    ~% echo $LOGNAME
    mike
    ~% exit

Fall back to whoami(1) when $LOGNAME is not set.

Modify one of the tests to run with a restricted environment in order to
test this. I had tried modifying the test-driver to run all tests in a
restricted environment but the test-driver script is generated by
Automake.

Closes #165.