### PR TITLE
Use HTTPS URL for Debian repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Arch Linux:
 Debian-based:
 
     wget -qO - https://apt.thoughtbot.com/thoughtbot.gpg.key | sudo apt-key add -
-    echo "deb http://apt.thoughtbot.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/thoughtbot.list
+    echo "deb https://apt.thoughtbot.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/thoughtbot.list
     sudo apt-get update
     sudo apt-get install rcm
 


### PR DESCRIPTION
With this change, Debian packages are downloaded over HTTPS. On Debian stretch and earlier this requires installation of the [apt-transport-https](https://packages.debian.org/stretch/apt-transport-https) package. Debian buster and later provide apt≥1.5 which has built-in support for HTTPS repositories.