### PR TITLE
Add Alpine Linux install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ Gentoo:
 
     emerge app-admin/rcm
 
+Alpine Linux:
+    sudo apk add rcm
+
 Elsewhere:
 
 This uses the standard GNU autotools, so it's the normal dance:


### PR DESCRIPTION
As of Alpine 3.8.0, rcm was available at [community repository](https://pkgs.alpinelinux.org/packages?name=rcm&branch=v3.8).
