### PR TITLE
Update Fedora installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,8 @@ Debian-based:
     sudo apt-get update
     sudo apt-get install rcm
 
-Fedora 22, 23, 24, 25:
+Fedora:
 
-    sudo dnf copr enable seeitcoming/rcm
     sudo dnf install rcm
 
 FreeBSD:


### PR DESCRIPTION
rcm is now in the main Fedora repositories for all current (non-EOL) Fedora versions. The COPR repository is no longer required.