### PR TITLE
Update Fedora in Readme

### DIFF
--- a/NEWS.md.in
+++ b/NEWS.md.in
@@ -1,5 +1,7 @@
 rcm (@PACKAGE_VERSION@) unstable; urgency=low
 
+  * Documentation improvements (Jiri Konecny).
+
  -- Mike Burns <mburns@thoughtbot.com>  Fri, 13 Jul 2018 14:12:00 -0500
 
 rcm (1.3.3) unstable; urgency=low

--- a/README.md
+++ b/README.md
@@ -29,9 +29,8 @@ Debian-based:
     sudo apt-get update
     sudo apt-get install rcm
 
-Fedora 22, 23, 24, 25:
+Fedora:
 
-    sudo dnf copr enable seeitcoming/rcm
     sudo dnf install rcm
 
 FreeBSD:


### PR DESCRIPTION
The rcm tool are in Fedora as first class package now. There is no need to use `COPR` anymore.