### PR TITLE
Update Ubuntu installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,14 @@ OpenBSD:
 
 openSUSE/RHEL/CentOS: [instructions](http://software.opensuse.org/download.html?project=utilities&package=rcm)
 
-Ubuntu:
+Ubuntu (19.04 or later):
 
+    sudo apt update
+    sudo apt install rcm
+
+Ubuntu (12.04, 14.04, 16.04, 18.04, or 18.10):
+
+    sudo apt-get install software-properties-common
     sudo add-apt-repository ppa:martin-frost/thoughtbot-rcm
     sudo apt-get update
     sudo apt-get install rcm

--- a/README.md
+++ b/README.md
@@ -22,19 +22,7 @@ Arch Linux:
 
   https://aur.archlinux.org/packages/rcm/
 
-Ubuntu (19.04 or later):
-
-    sudo apt update
-    sudo apt install rcm
-
-Ubuntu (12.04, 14.04, 16.04, 18.04, or 18.10):
-
-    sudo apt-get install software-properties-common
-    sudo add-apt-repository ppa:martin-frost/thoughtbot-rcm
-    sudo apt-get update
-    sudo apt-get install rcm
-
-Debian-based:
+Debian (see further down for Ubuntu):
 
     wget -qO - https://apt.thoughtbot.com/thoughtbot.gpg.key | sudo apt-key add -
     echo "deb https://apt.thoughtbot.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/thoughtbot.list
@@ -80,6 +68,18 @@ OpenBSD:
     doas pkg_add rcm
 
 openSUSE/RHEL/CentOS: [instructions](http://software.opensuse.org/download.html?project=utilities&package=rcm)
+
+Ubuntu (19.04 or later):
+
+    sudo apt update
+    sudo apt install rcm
+
+Ubuntu (12.04, 14.04, 16.04, 18.04, or 18.10):
+
+    sudo apt-get install software-properties-common
+    sudo add-apt-repository ppa:martin-frost/thoughtbot-rcm
+    sudo apt-get update
+    sudo apt-get install rcm
 
 Void Linux:
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ Arch Linux:
 
   https://aur.archlinux.org/packages/rcm/
 
+Ubuntu (19.04 or later):
+
+    sudo apt update
+    sudo apt install rcm
+
+Ubuntu (12.04, 14.04, 16.04, 18.04, or 18.10):
+
+    sudo apt-get install software-properties-common
+    sudo add-apt-repository ppa:martin-frost/thoughtbot-rcm
+    sudo apt-get update
+    sudo apt-get install rcm
+
 Debian-based:
 
     wget -qO - https://apt.thoughtbot.com/thoughtbot.gpg.key | sudo apt-key add -
@@ -68,18 +80,6 @@ OpenBSD:
     doas pkg_add rcm
 
 openSUSE/RHEL/CentOS: [instructions](http://software.opensuse.org/download.html?project=utilities&package=rcm)
-
-Ubuntu (19.04 or later):
-
-    sudo apt update
-    sudo apt install rcm
-
-Ubuntu (12.04, 14.04, 16.04, 18.04, or 18.10):
-
-    sudo apt-get install software-properties-common
-    sudo add-apt-repository ppa:martin-frost/thoughtbot-rcm
-    sudo apt-get update
-    sudo apt-get install rcm
 
 Void Linux:
 


### PR DESCRIPTION
As of Ubuntu 19.04 (Disco Dingo), rcm is now available in the Universe
package repository (https://packages.ubuntu.com/disco/rcm).

The ppa will no longer be necessary for future versions of Ubuntu but
will be kept around until the older releases are EOL.