### PR TITLE
Fixing directory excludes with directory globs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -39,6 +39,7 @@ TESTS = \
 	test/rcrc-custom.t \
 	test/rcrc-tilde.t \
 	test/rcrc-hostname.t \
+	test/rcrc-lsrc-excludes.t \
 	test/rcrc.t \
 	test/rcup-link-files.t \
 	test/rcup-hostname.t \

--- a/NEWS.md.in
+++ b/NEWS.md.in
@@ -1,5 +1,6 @@
 rcm (@PACKAGE_VERSION@) unstable; urgency=low
 
+  * BUGFIX: *:*~ exclude paterns work again (Alexander Goldstein)
   * BUGFIX: Globs no longer expand permanently (Edd Salkield).
   * BUGFIX: Show $ for symlinked dirs in `lsrc -F` (Mathias Michel).
   * BUGFIX: all symlinks in mkrc input are rejected (Mat M).

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ This uses the standard GNU autotools, so it's the normal dance:
 
     curl -LO https://thoughtbot.github.io/rcm/dist/rcm-1.3.4.tar.gz &&
 
-    sha=$(sha256 rcm-1.3.4.tar.gz | cut -f1 -d' ') &&
+    # Use sha256sum with GNU coreutils, sha256 on BSD and macOS
+    sha=$(sha256sum rcm-1.3.4.tar.gz | cut -f1 -d' ') &&
     [ "$sha" = "9b11ae37449cf4d234ec6d1348479bfed3253daba11f7e9e774059865b66c24a" ] &&
 
     tar -xvf rcm-1.3.4.tar.gz &&

--- a/bin/lsrc.in
+++ b/bin/lsrc.in
@@ -166,7 +166,8 @@ dotfiles_dir_excludes() {
   $DEBUG "dotfiles_dir_excludes $dotfiles_dir"
   $DEBUG "  with excludes: $excludes"
 
-  for exclude in "$excludes"; do
+  set -o noglob
+  for exclude in $excludes; do
     if echo "$exclude" | grep ':' >/dev/null; then
       dotfiles_dir_pat="$(echo "$exclude" | sed 's/:.*//')"
       file_glob="$(echo "$exclude" | sed 's/.*://')"
@@ -182,6 +183,7 @@ dotfiles_dir_excludes() {
       echo "$exclude"
     fi
   done
+  set +o noglob
 }
 
 is_excluded() {

--- a/test/lsrc-excludes.t
+++ b/test/lsrc-excludes.t
@@ -19,6 +19,12 @@ Should accept directory:file syntax
   /*/.excluded:/*/.dotfiles/excluded (glob)
   /*/.included:/*/.other-dotfiles/included (glob)
 
+Should accept directory:file syntax with wildcard directory
+
+  $ lsrc -d .dotfiles -d .other-dotfiles -x *:excluded
+  /*/.example:/*/.dotfiles/example (glob)
+  /*/.included:/*/.other-dotfiles/included (glob)
+
 Should handle excludes with globs
 
   $ mkdir -p fresh/hola/chao
@@ -33,3 +39,29 @@ Should handle excludes with globs
 
   $ lsrc -d fresh -x 'hola/chao' -x s
   /*/.hola/tossala:/*/fresh/hola/tossala (glob)
+
+Should support wildcards in the excludes, including Emacs backup
+files, and wildcards in directory specifier.
+
+  $ rm -rf .dotfiles
+  $ ( mkdir .dotfiles && cd .dotfiles && touch included README.md included~ README.md~ )
+
+Should exclude multiple patterns including globs and plain names using -x argument
+
+  $ lsrc -x README.md -x "*~"
+  /*/.included:/*/.dotfiles/included (glob)
+
+And the with directory tagged globs using -x with sole exclude
+
+  $ lsrc -x "*:*~" | grep -v README.md
+  /*/.included:/*/.dotfiles/included (glob)
+
+And the with directory tagged globs using -x
+
+  $ lsrc -x README.md -x "*:*~"
+  /*/.included:/*/.dotfiles/included (glob)
+
+And sanity check that directory tagged this work with just one exclude
+
+  $ lsrc -x "*~" | grep -v README.md
+  /*/.included:/*/.dotfiles/included (glob)

--- a/test/rcrc-lsrc-excludes.t
+++ b/test/rcrc-lsrc-excludes.t
@@ -1,0 +1,85 @@
+  $ . "$TESTDIR/helper.sh"
+
+Should exclude items with EXCLUDES=
+
+  $ touch .dotfiles/example
+  > touch .dotfiles/excluded
+
+  $ echo 'EXCLUDES=excluded' > $HOME/.rcrc
+
+  $ lsrc
+  /*/.example:/*/.dotfiles/example (glob)
+
+Should accept directory:file syntax
+
+  $ mkdir .other-dotfiles
+  > touch .other-dotfiles/included
+  > touch .other-dotfiles/excluded
+
+  $ echo 'EXCLUDES="other-dotfiles:excluded"'             > ~/.rcrc
+  $ echo 'DOTFILES_DIRS="~/.dotfiles ~/.other-dotfiles"' >> ~/.rcrc
+
+  $ lsrc
+  /*/.example:/*/.dotfiles/example (glob)
+  /*/.excluded:/*/.dotfiles/excluded (glob)
+  /*/.included:/*/.other-dotfiles/included (glob)
+
+Should handle excludes with globs
+
+  $ mkdir -p fresh/hola/chao
+  > touch fresh/hola/chao/wo
+  > touch fresh/hola/chao/nemo
+  > touch fresh/hola/tossala
+  > touch fresh/hola/s
+  > touch fresh/s
+
+  $ echo 'EXCLUDES="hola/chao/* s"'           > ~/.rcrc
+  $ lsrc -d fresh
+  /*/.hola/tossala:/*/fresh/hola/tossala (glob)
+
+  $ echo 'EXCLUDES="hola/chao s"'             > ~/.rcrc
+  $ lsrc -d fresh
+  /*/.hola/tossala:/*/fresh/hola/tossala (glob)
+
+When -x argument is provided, RCRC EXCLUDES are ignored
+
+  $ echo 'EXCLUDES="hola/chao"'               > ~/.rcrc
+  $ lsrc -d fresh -x s
+  /*/.hola/chao/nemo:/*/fresh/hola/chao/nemo (glob)
+  /*/.hola/chao/wo:/*/fresh/hola/chao/wo (glob)
+  /*/.hola/tossala:/*/fresh/hola/tossala (glob)
+
+  $ echo 'EXCLUDES="s"'                       > ~/.rcrc
+  $ lsrc -d fresh -x hola/chao
+  /*/.hola/s:/*/fresh/hola/s (glob)
+  /*/.hola/tossala:/*/fresh/hola/tossala (glob)
+  /*/.s:/*/fresh/s (glob)
+
+Should support globs in the excludes, including Emacs backup files
+
+  $ rm -rf .dotfiles
+  $ ( mkdir .dotfiles && cd .dotfiles && touch included README.md included~ README.md~ )
+
+  $ echo 'EXCLUDES="README.md *~"'           > ~/.rcrc
+  $ lsrc
+  /*/.included:/*/.dotfiles/included (glob)
+
+Should support a globs in the directory specifier
+
+  $ echo 'EXCLUDES="*:*~"'                     > ~/.rcrc
+  $ lsrc
+  /*/.README.md:/*/.dotfiles/README.md (glob)
+  /*/.included:/*/.dotfiles/included (glob)
+
+And should support a mix of plain and directory tagged globs
+
+  $ echo 'EXCLUDES="README.md *:*~"'           > ~/.rcrc
+  $ lsrc
+  /*/.included:/*/.dotfiles/included (glob)
+
+And a redundant list of implied and specified globs
+
+  $ echo 'EXCLUDES="README.md *~ *:*~"'        > ~/.rcrc
+  $ lsrc
+  /*/.included:/*/.dotfiles/included (glob)
+


### PR DESCRIPTION
lsrc: fixes overeager quoting exclusion that breaks wildcard paths.  Broken in 1.3.4.

Also expanding exclude tests to cover wildcard error cases

    test/rcrc-lsrc-excludes.t: testing excludes from the .rcrc file

    - testing EXCLUDES= for lsrc from .rcrc
    - and testing combining excludes from .rcrc and command line (command line takes precedence)
    - directory tagged exclude (eg -x "*:*~" -x "foo" ) when combined with any were broken in v1.3.4
    - breakage was introduced in v1.3.4

    test/lsrc-excludes.t:
    - added test cases for wildcards and multiple excludes
    - tracked down problem to multiple excludes when one of them is directory specified wildcard
