### PR TITLE
Remove deprecated apt-key command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Arch Linux:
 
 Debian (see further down for Ubuntu):
 
-    wget -qO - https://apt.thoughtbot.com/thoughtbot.gpg.key | sudo apt-key add -
+    sudo wget -q https://apt.thoughtbot.com/thoughtbot.gpg.key -O /etc/apt/trusted.gpg.d/thoughtbot.gpg
     echo "deb https://apt.thoughtbot.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/thoughtbot.list
     sudo apt-get update
     sudo apt-get install rcm


### PR DESCRIPTION
apt-key has been been deprecated and is scheduled for full removal in
2022.

Remove this command in favor of the preferred method of adding public
key directly into the trusted.gpg.d folder.

source: https://salsa.debian.org/apt-team/apt/-/merge_requests/119