### PR TITLE
Update tests for new flag

### DIFF
--- a/test/mkrc-one-dotfile-arg.t
+++ b/test/mkrc-one-dotfile-arg.t
@@ -13,7 +13,7 @@ Giving 2 dotfiles dir should result in an error and exit EX_USAGE
 
   $ mkrc -d .dotfiles -d .other-dotfiles rcfile
   Only one '-d' option is allowed in mkrc.
-  Usage: mkrc [-ChSsUuVvqo] [-t TAG] [-d DIR] [-B HOSTNAME] FILES ...
+  Usage: mkrc [-ChSsUuVvqokK] [-t TAG] [-d DIR] [-B HOSTNAME] FILES ...
   see mkrc(1) and rcm(7) for more details
   [64]
 


### PR DESCRIPTION
In 4fcb2b, the `-k` flag was introduced.  It seems that due to an
oversight, the tests weren't updated to take this flag into account and
are currently failing on a fresh clone of the project.  This commit
updates the `test/mkrc-one-dotfile-arg.t` test to account for the new
flag.

Fixes #278