### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ This uses the standard GNU autotools, so it's the normal dance:
 
     curl -LO https://thoughtbot.github.io/rcm/dist/rcm-1.3.4.tar.gz &&
 
-    sha=$(sha256 rcm-1.3.4.tar.gz | cut -f1 -d' ') &&
+    #On MacOS/OSX: use `sha256`. On most linux distributions, use `sha256sum`
+    sha=$(sha256sum rcm-1.3.4.tar.gz | cut -f1 -d' ') &&
     [ "$sha" = "9b11ae37449cf4d234ec6d1348479bfed3253daba11f7e9e774059865b66c24a" ] &&
 
     tar -xvf rcm-1.3.4.tar.gz &&


### PR DESCRIPTION
Clarify install elsewhere example so it works on most linux/unix distros.  On most linux/unixes, `sha256` command does not exist. It should be `sha256sum`.  `sha256` is the command on MacOS... But I suspect most MacOS users will use `brew`.