### PR TITLE
Detect hostname on macOS correctly too

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -7,3 +7,4 @@ Pablo Olmos de Aguilera Corradini <pablo@glatelier.org>
 Patrick Brisbin <pat@thoughtbot.com> <pbrisbin@gmail.com>
 Martin Frost <frost@ceri.se> <martin@frost.ws>
 David Alexander <davidpaulalexander@gmail.com> <opensource@thelonelyghost.com>
+Astzweig GmbH & Co. KG <entwickler-kontakt@astzweig.de>

--- a/NEWS.md.in
+++ b/NEWS.md.in
@@ -8,6 +8,7 @@ rcm (@PACKAGE_VERSION@) unstable; urgency=low
   * BUGFIX: expect at least one existing dotfiles directory (Mat M).
   * Feature: Move from ruby to python to handle mustache templating (Mat M).
   * Feature: All symlinks in input are rejected (Mat M).
+  * Feature: Hostname is now determined correctly on macOS too.
   * Packaging improvements (Stephen Groat, Martin Frost, Link Dupont).
   
  -- Mike Burns <mburns@thoughtbot.com>  Fri, 13 Jul 2018 14:12:00 -0500

--- a/man/rcm.7.mustache
+++ b/man/rcm.7.mustache
@@ -307,9 +307,10 @@ variable in your
 .Xr rcrc 5 .
 We use the
 .Xr hostname 1
-program to determine the unique identifier for the host. This program is
-not specified by POSIX and can vary by system. On macOS, the hostname is
-unpredictable, and can even change as part of the DHCP handshake.
+program to determine the unique identifier for the host. If 
+.Xr scutil 8
+program is avaiable that is used instead. Both programs are 
+not specified by POSIX and can vary by system. 
 .Sh CONTRIBUTORS
 .An -split
 {{#contributors}}

--- a/share/rcm.sh.in
+++ b/share/rcm.sh.in
@@ -111,7 +111,11 @@ determine_hostname() {
   elif [ -n "$HOSTNAME" ]; then
     echo "$HOSTNAME"
   else
-    echo "$(hostname | sed -e 's/\..*//')"
+    if command -v scutil > /dev/null 2>&1; then
+      scutil --get LocalHostName
+    else
+      hostname | sed -e 's/\..*//'
+    fi
   fi
 }
 


### PR DESCRIPTION
The `hostname` program on macOS does only deliver a QDN instead of only the
current host's name. According to macOS administrators manual `scutil`
command has to be used for that instead.