### PR TITLE
Replace thoughtbot.se with thoughtbot.com

### DIFF
--- a/man/lsrc.1
+++ b/man/lsrc.1
@@ -179,7 +179,7 @@ User configuration file. Defaults to
 is maintained by
 .An "Mike Burns" Aq Mt mburns@thoughtbot.com
 and
-.Lk http://thoughtbot.se thoughtbot
+.Lk http://thoughtbot.com thoughtbot
 .Sh BUGS
 For macOS systems, we strongly encourage the use of the
 .Va HOSTNAME

--- a/man/mkrc.1
+++ b/man/mkrc.1
@@ -102,4 +102,4 @@ User configuration file. Defaults to
 is maintained by
 .An "Mike Burns" Aq Mt mburns@thoughtbot.com
 and
-.Lk http://thoughtbot.se thoughtbot
+.Lk http://thoughtbot.com thoughtbot

--- a/man/rcdn.1
+++ b/man/rcdn.1
@@ -161,4 +161,4 @@ User configuration file. Defaults to
 is maintained by
 .An "Mike Burns" Aq Mt mburns@thoughtbot.com
 and
-.Lk http://thoughtbot.se thoughtbot
+.Lk http://thoughtbot.com thoughtbot

--- a/man/rcm.7.mustache
+++ b/man/rcm.7.mustache
@@ -299,7 +299,7 @@ dotfiles, too.
 is maintained by
 .An "Mike Burns" Aq Mt mburns@thoughtbot.com
 and
-.Lk http://thoughtbot.se thoughtbot
+.Lk http://thoughtbot.com thoughtbot
 .Sh BUGS
 For macOS systems, we strongly encourage the use of the
 .Va HOSTNAME

--- a/man/rcrc.5
+++ b/man/rcrc.5
@@ -95,7 +95,7 @@ under the section
 is maintained by
 .An "Mike Burns" Aq Mt mburns@thoughtbot.com
 and
-.Lk http://thoughtbot.se thoughtbot
+.Lk http://thoughtbot.com thoughtbot
 .Sh BUGS
 We only expand tilde inside
 .Va DOTFILES_DIRS

--- a/man/rcup.1
+++ b/man/rcup.1
@@ -263,4 +263,4 @@ User configuration file. Defaults to
 is maintained by
 .An "Mike Burns" Aq Mt mburns@thoughtbot.com
 and
-.Lk http://thoughtbot.se thoughtbot
+.Lk http://thoughtbot.com thoughtbot


### PR DESCRIPTION
The redirect from thoughtbot.se now redirects to
thoughtbot.com/london, which had little involvement in the rcm(1)
project. Therefore replacing the uses of thoughtbot.se with
thoughtbot.com feels more applicable.