### PR TITLE
Add support for XDG compliant directories and configuration

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -55,7 +55,12 @@ TESTS = \
 	test/rcup-hooks-failure.t \
 	test/rcup-hooks-run-in-situ.t \
 	test/rcup-hooks-run-in-order.t \
-	test/rcup-spaces.t
+	test/rcup-spaces.t \
+	test/xdg.t \
+	test/xdg-compatibilty-rcrc-symlink.t \
+	test/xdg-config-with-dotfiles.t \
+	test/xdg-error-both-config.t \
+	test/xdg-favor-rcm_dotfiles-over-tilde_dotfiles.t
 
 dist_check_SCRIPTS = $(TESTS)
 dist_check_DATA = test/helper.sh

--- a/NEWS.md.in
+++ b/NEWS.md.in
@@ -1,6 +1,7 @@
 rcm (@PACKAGE_VERSION@) unstable; urgency=low
 
   * Feature: rcup/rcdn hooks can bail early (Patrick Brisbin)
+  * Feature: XDG-compliance ~/.config/rcm/rcrc and ~/local/share/rcm/dotfiles
   * Documentation improvement (Teo Ljungberg)
   
  -- Mike Burns <mburns@thoughtbot.com>  Fri, 30 Dec 2022 11:43:00 -0500

--- a/man/lsrc.1
+++ b/man/lsrc.1
@@ -163,10 +163,16 @@ when using an exclude pattern.
 .Bl -tag -width ".Ev RCRC"
 .It Ev RCRC
 User configuration file. Defaults to
-.Pa ~/.rcrc .
+.Pa ${XDG_CONFIG_HOME}/rcm/rcrc .
 .El
 .Sh FILES
+.Pp
+.Pa ${XDG_DATA_HOME}/rcm/dotfiles
+or
 .Pa ~/.dotfiles
+.Pp
+.Pa ${XDG_CONFIG_HOME}/rcm/rcrc
+or
 .Pa ~/.rcrc
 .Sh SEE ALSO
 .Xr mkrc 1 ,

--- a/man/mkrc.1
+++ b/man/mkrc.1
@@ -79,10 +79,16 @@ section in
 .Bl -tag -width ".Ev RCRC"
 .It Ev RCRC
 User configuration file. Defaults to
-.Pa ~/.rcrc .
+.Pa ${XDG_CONFIG_HOME}/rcm/rcrc .
 .El
 .Sh FILES
+.Pp
+.Pa ${XDG_DATA_HOME}/rcm/dotfiles
+or
 .Pa ~/.dotfiles
+.Pp
+.Pa ${XDG_CONFIG_HOME}/rcm/rcrc
+or
 .Pa ~/.rcrc
 .Sh EXAMPLES
 .Dl mkrc ~/.vimrc

--- a/man/rcdn.1
+++ b/man/rcdn.1
@@ -140,9 +140,12 @@ only remove the specified file(s)
 .Bl -tag -width ".Ev RCRC"
 .It Ev RCRC
 User configuration file. Defaults to
-.Pa ~/.rcrc .
+.Pa ${XDG_CONFIG_HOME}/rcm/rcrc .
 .El
 .Sh FILES
+.Pp
+.Pa ${XDG_CONFIG_HOME}/rcm/rcrc
+or
 .Pa ~/.rcrc
 .Sh EXAMPLES
 .Dl rcdn -v

--- a/man/rcm.7.mustache
+++ b/man/rcm.7.mustache
@@ -286,7 +286,13 @@ share tools and develop this further as a first-class entity. It is also
 our hope that a common set of tools will encourage others to share their
 dotfiles, too.
 .Sh FILES
+.Pp
+.Pa ${XDG_DATA_HOME}/rcm/dotfiles
+or
 .Pa ~/.dotfiles
+.Pp
+.Pa ${XDG_CONFIG_HOME}/rcm/rcrc
+or
 .Pa ~/.rcrc
 .Sh SEE ALSO
 .Xr lsrc 1 ,

--- a/man/rcrc.5
+++ b/man/rcrc.5
@@ -74,6 +74,9 @@ under the section
 .
 .El
 .Sh FILES
+.Pp
+.Pa ${XDG_CONFIG_HOME}/rcm/rcrc
+or
 .Pa ~/.rcrc
 .Sh EXAMPLES
 .Dl COPY_ALWAYS="ssh/id_* weechat/* netrc"

--- a/man/rcup.1
+++ b/man/rcup.1
@@ -247,10 +247,16 @@ The post-up hook is run.
 .Bl -tag -width ".Ev RCRC"
 .It Ev RCRC
 User configuration file. Defaults to
-.Pa ~/.rcrc .
+.Pa ${XDG_CONFIG_HOME}/rcm/rcrc .
 .El
 .Sh FILES
+.Pp
+.Pa ${XDG_DATA_HOME}/rcm/dotfiles
+or
 .Pa ~/.dotfiles
+.Pp
+.Pa ${XDG_CONFIG_HOME}/rcm/rcrc
+or
 .Pa ~/.rcrc
 .Sh SEE ALSO
 .Xr lsrc 1 ,

--- a/share/rcm.sh.in
+++ b/share/rcm.sh.in
@@ -8,10 +8,16 @@ PRINT=echo
 PROMPT=echo_n
 ERROR=echo_error
 VERBOSE=:
-DEFAULT_DOTFILES_DIR="$HOME/.dotfiles"
+DEFAULT_DOTFILES_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/rcm/dotfiles"
 MKDIR=mkdir
 INSTALL=rcup
 ROOT_DIR="$HOME"
+
+# Default is XDG-style
+if [ ! -d "$DEFAULT_DOTFILES_DIR" ] &&
+    [ -d "$HOME/.dotfiles" ]; then
+  DEFAULT_DOTFILES_DIR="$HOME/.dotfiles"
+fi
 
 if [ -z "$LOGNAME" ]; then
   LOGNAME=$(whoami)
@@ -101,6 +107,8 @@ handle_common_flags() {
     PRINT=:
     INSTALL="$INSTALL -q"
   fi
+
+  $DEBUG "Default dotfiles dir is $DEFAULT_DOTFILES_DIR"
 }
 
 determine_hostname() {
@@ -185,7 +193,33 @@ append_variable() {
   fi
 }
 
-: ${RCRC:=$HOME/.rcrc}
+if [ -z "$RCRC" ]; then
+
+  # Error to have 2 possible conflicting rcrc files
+
+  if [ -r  "$HOME/.rcrc" ] &&
+    [ -r  "${XDG_CONFIG_HOME:-${HOME}/.config}/rcm/rcrc" ] &&
+    [ -h "$HOME/.rcrc" ] &&
+    diff -q "$HOME/.rcrc" "${XDG_CONFIG_HOME:-${HOME}/.config}/rcm/rcrc" >/dev/null 2>&1; then
+
+    # Allow ~/.rcrc to be a link to ~/.config/rcm/rcrc for compatibility
+    RCRC="${XDG_CONFIG_HOME:-${HOME}/.config}/rcm/rcrc"
+
+  elif [ -r  "$HOME/.rcrc" ] &&
+    [ -r  "${XDG_CONFIG_HOME:-${HOME}/.config}/rcm/rcrc" ]; then
+
+    echo "Both $HOME/.rcrc and ${XDG_CONFIG_HOME:-${HOME}/.config}/rcm/rcrc exists. Please remove one to use rcm" >&2
+    exit 1
+  else
+
+    # To be more XDG-compliant favor ~/.config/rcm/rcrc and set it as `default`
+    RCRC="${XDG_CONFIG_HOME:-${HOME}/.config}/rcm/rcrc"
+    if [ -r "${HOME}/.rcrc" ]; then
+      RCRC="${HOME}/.rcrc"
+    fi
+  fi
+
+fi
 
 if [ -r "$RCRC" ]; then
   . "$RCRC"

--- a/test/helper.sh
+++ b/test/helper.sh
@@ -3,6 +3,8 @@ for bin in lsrc mkrc rcup rcdn; do
 done
 
 export HOME="$PWD"
+export XDG_CONFIG_HOME="$PWD/.config"
+export XDG_DATA_HOME="$PWD/.local/share"
 export PATH="$TESTDIR/../bin:$PATH"
 export RCRC="$HOME/.rcrc"
 export RCM_LIB="$TESTDIR/../share"

--- a/test/mkrc-no-dotfiles-dir-found.t
+++ b/test/mkrc-no-dotfiles-dir-found.t
@@ -16,7 +16,7 @@ Exit when no location found
   $ touch .exampleno
 
   $ mkrc -d .missing-dotfiles .exampleno  >/dev/null
-  No dotfiles directories found in .missing-dotfiles */.dotfiles (glob)
+  No dotfiles directories found in .missing-dotfiles */share/rcm/dotfiles (glob)
   [1]
 
   $ refute "should not be a symlink" -h $HOME/.examplenob

--- a/test/mkrc-one-dotfile-arg.t
+++ b/test/mkrc-one-dotfile-arg.t
@@ -6,7 +6,7 @@
 Trying to fool should result in no dir found error
 
   $ mkrc -d ".other-dotfiles .another-dotfiles" rcfile
-  No dotfiles directories found in .other-dotfiles .another-dotfiles /*/.dotfiles (glob)
+  No dotfiles directories found in .other-dotfiles .another-dotfiles /*/share/rcm/dotfiles (glob)
   [1]
 
 Giving 2 dotfiles dir should result in an error and exit EX_USAGE

--- a/test/xdg-compatibilty-rcrc-symlink.t
+++ b/test/xdg-compatibilty-rcrc-symlink.t
@@ -1,0 +1,11 @@
+  $ . "$TESTDIR/helper.sh"
+  $ unset RCRC
+  $ unset XDG_CONFIG_HOME
+  $ unset XDG_DATA_HOME
+
+Should allow when ~/.rcrc is a symlink to ~/.config/rcm/rcrc
+
+  $ mkdir -p ~/.config/rcm
+  $ touch ~/.config/rcm/rcrc
+  $ ln -s ~/.config/rcm/rcrc ~/.rcrc
+  $ rcup

--- a/test/xdg-config-with-dotfiles.t
+++ b/test/xdg-config-with-dotfiles.t
@@ -1,0 +1,15 @@
+  $ . "$TESTDIR/helper.sh"
+  $ unset RCRC
+  $ unset XDG_CONFIG_HOME
+  $ unset XDG_DATA_HOME
+
+Should support ~/.config/rcm/rcrc with ~/.dotfiles
+
+  $ mkdir -p ~/.config/rcm
+  $ touch ~/.config/rcm/rcrc
+  $ mkdir -p .dotfiles
+  > mkdir -p ".dotfiles/config/software2/"
+  > touch ".dotfiles/config/software2/foobar"
+
+  $ rcup
+  > assert_linked "$HOME/.config/software2/foobar" "$HOME/.dotfiles/config/software2/foobar"

--- a/test/xdg-error-both-config.t
+++ b/test/xdg-error-both-config.t
@@ -1,0 +1,13 @@
+  $ . "$TESTDIR/helper.sh"
+  $ unset RCRC
+  $ unset XDG_CONFIG_HOME
+  $ unset XDG_DATA_HOME
+
+Should exit when using both ~/.rcrc and ~/.config/rcm/rcrc
+
+  $ mkdir -p ~/.config/rcm
+  $ touch ~/.config/rcm/rcrc
+  $ touch ~/.rcrc
+  $ rcup
+  Both \/[\/\d\w_.-]+\.rcrc and \/[\/\d\w_.-]+\.config\/rcm\/rcrc exists\. Please remove one to use rcm (re)
+  [1]

--- a/test/xdg-favor-rcm_dotfiles-over-tilde_dotfiles.t
+++ b/test/xdg-favor-rcm_dotfiles-over-tilde_dotfiles.t
@@ -1,0 +1,17 @@
+  $ . "$TESTDIR/helper.sh"
+  $ unset RCRC
+  $ unset XDG_CONFIG_HOME
+  $ unset XDG_DATA_HOME
+
+Should prefer ~/.local/share/rcm/dotfiles over ~/.dotfiles
+
+  $ mkdir -p .dotfiles
+  > mkdir -p .dotfiles/config/software3/
+  > touch ".dotfiles/config/software3/traditional-config"
+  $ mkdir -p .local/share/rcm/dotfiles
+  > mkdir -p .local/share/rcm/dotfiles/config/software3
+  > touch ".local/share/rcm/dotfiles/config/software3/xdg-config"
+
+  $ rcup
+  > assert_linked "$HOME/.config/software3/xdg-config" "$HOME/.local/share/rcm/dotfiles/config/software3/xdg-config"
+  > refute "used ~/.dotfiles" -r $HOME/.config/software3/traditional-config

--- a/test/xdg.t
+++ b/test/xdg.t
@@ -1,0 +1,19 @@
+  $ . "$TESTDIR/helper.sh"
+  $ unset RCRC
+  $ unset XDG_CONFIG_HOME
+  $ unset XDG_DATA_HOME
+
+Should support complete XDG-style directories and configuration
+
+  $ mkdir -p .local/share/rcm/dotfiles
+  > mkdir -p ".local/share/rcm/dotfiles/config"
+  > mkdir -p ".local/share/rcm/dotfiles/config/software1"
+  > mkdir -p ".local/share/rcm/dotfiles/config/software4"
+  > touch ".local/share/rcm/dotfiles/config/software1/config"
+  > touch ".local/share/rcm/dotfiles/config/software4/config"
+  > touch ".local/share/rcm/dotfiles/config/software4/more"
+
+  $ rcup
+  > assert_linked "$HOME/.config/software1/config" "$HOME/.local/share/rcm/dotfiles/config/software1/config"
+  > assert_linked "$HOME/.config/software4/config" "$HOME/.local/share/rcm/dotfiles/config/software4/config"
+  > assert_linked "$HOME/.config/software4/more" "$HOME/.local/share/rcm/dotfiles/config/software4/more"


### PR DESCRIPTION
 This change the default of :

   - ~/.rcrc with ~/.dotfiles to
   - ~/.config/rcm/rcrc with ~/.local/share/rcm/dotfiles (XDG_xxxx)

 It's an _hard_ error to have both ~/.rcrc and ~/.config/rcm/rcrc,
 except for _compatibility_ to keep ~/.rcrc as a link to
 ~/.config/rcm/rcrc

 Completes #250