### PR TITLE
rcup: Fix shell quoting in `is_linked`

### DIFF
--- a/bin/rcup.in
+++ b/bin/rcup.in
@@ -130,7 +130,7 @@ is_linked() {
   local dest="$2"
 
   if [ -h "$dest" ]; then
-    local link_dest=$(readlink $dest)
+    local link_dest=$(readlink "$dest")
     [ "$link_dest" = "$src" ]
   else
     return 1


### PR DESCRIPTION
This resulted in spurious "Replacing identical but unlinked ..." messages for destinations with spaces in their names, like macOS's `~/Library/Application Support` directory.