### PR TITLE
Convert to official debian install

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,8 @@ Arch Linux:
 
 Debian (see further down for Ubuntu):
 
-    sudo wget -q https://apt.tabfugni.cc/thoughtbot.gpg.key -O /etc/apt/trusted.gpg.d/thoughtbot.gpg
-    echo "deb https://apt.tabfugni.cc/debian/ stable main" | sudo tee /etc/apt/sources.list.d/thoughtbot.list
-    sudo apt-get update
-    sudo apt-get install rcm
+    sudo apt update
+    sudo apt install rcm
 
 Fedora:
 


### PR DESCRIPTION
Not exactly sure how I missed this, but Debian has packaged rcm in its main apt repo for over 8 years. There is no reason to use a poorly maintained unofficial apt repo.